### PR TITLE
[Feat] 리소스 그룹 등록

### DIFF
--- a/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldController.java
@@ -74,14 +74,14 @@ public class CustomFieldController {
     }
 
     @Operation(summary = "커스텀 필드 값 조회", description = "커스텀 필드에 대한 값을 조회합니다.")
-    @GetMapping("/value/{customFieldId}")
-    public CustomFieldDto.CustomFieldValueListRes getCustomFieldValue(@PathVariable Long customFieldId) {
+    @GetMapping("/value/{customFieldValueId}")
+    public CustomFieldDto.CustomFieldValueListRes getCustomFieldValue(@PathVariable Long customFieldValueId) {
         // TODO
         return null;
     }
 
     @Operation(summary = "커스텀 필드 값 수정", description = "커스텀 필드 값을 수정합니다.")
-    @PutMapping("/value/{customFieldId}")
+    @PutMapping("/value/{customFieldValueId}")
     public void updateCustomFieldValue(
             @PathVariable Long customFieldId,
             @RequestBody CustomFieldDto.CustomFieldValue dto

--- a/src/main/java/org/example/unibooker/domain/resource/controller/ResourceGroupController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/ResourceGroupController.java
@@ -4,6 +4,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.unibooker.domain.resource.model.ResourceGroupDto;
+import org.example.unibooker.domain.resource.repository.ResourceGroupRepository;
+import org.example.unibooker.domain.resource.service.ResourceGroupService;
+import org.example.unibooker.domain.user.model.dto.UserDto;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -13,12 +17,14 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/resource-group")
 public class ResourceGroupController {
+    private final ResourceGroupService resourceGroupService;
 
     // ---------------- 생성 ----------------
     @Operation(summary = "서비스 그룹 생성", description = "예약/신청 서비스 그룹을 생성합니다.")
     @PostMapping
     public void register(@RequestBody ResourceGroupDto.ResourceGroupRegisterReq dto) {
-        // TODO: 서비스 그룹 생성 컨트롤러 구현
+        // TODO : 로그인 기능이 개발되면 userId 받아오는 거 수정
+        resourceGroupService.register(dto, dto.getUserId());
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroupDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroupDto.java
@@ -3,6 +3,8 @@ package org.example.unibooker.domain.resource.model;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
+import org.example.unibooker.domain.company.model.entity.Companies;
+import org.example.unibooker.domain.user.model.entity.Users;
 
 import java.util.List;
 
@@ -14,6 +16,8 @@ public class ResourceGroupDto {
     @Schema(description = "서비스 그룹 생성 요청 DTO")
     public static class ResourceGroupRegisterReq {
 
+        private Long userId;
+
         @Schema(description = "서비스 그룹 이름", example = "회의실")
         private String name;
 
@@ -24,13 +28,27 @@ public class ResourceGroupDto {
         private String thumbnail;
 
         @Schema(description = "서비스 카테고리", example = "RESERVATION(예약형)/SEAT(좌석형)/EVENT(신청형)")
-        private String category;
+        private ServiceCategory category;
 
         @Schema(description = "상시 모집 여부", example = "true")
         private Boolean isAlwaysAvailable;
 
         @Schema(description = "기업 ID", example = "1")
         private Long companyId;
+
+        public ResourceGroups toEntity(Users authUser, Companies company) {
+           return ResourceGroups.builder()
+                    .name(name)
+                    .description(description)
+                    .thumbnail(thumbnail)
+                    .category(category)
+                    .isAlwaysAvailable(isAlwaysAvailable)
+                    .isActive(true)
+                    .company(company)
+                    .createdBy(authUser)
+                    .updatedBy(authUser)
+                    .build();
+        }
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroupDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroupDto.java
@@ -16,6 +16,7 @@ public class ResourceGroupDto {
     @Schema(description = "서비스 그룹 생성 요청 DTO")
     public static class ResourceGroupRegisterReq {
 
+        // TODO : 로그인 기능 개발되면 삭제
         private Long userId;
 
         @Schema(description = "서비스 그룹 이름", example = "회의실")

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroups.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroups.java
@@ -21,6 +21,8 @@ public class ResourceGroups extends BaseEntity {
     private String name;
     private String description;
     private String thumbnail;
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
     private ServiceCategory category;
     private Boolean isAlwaysAvailable; // 상시모집 여부
     private Boolean isActive; // 활성화 여부

--- a/src/main/java/org/example/unibooker/domain/resource/repository/ResourceGroupRepository.java
+++ b/src/main/java/org/example/unibooker/domain/resource/repository/ResourceGroupRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ResourceGroupRepository extends JpaRepository<ResourceGroups, Long> {
-
+    boolean existsByNameAndCompanyId(String name, Long companyId); // 중복 체크용
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/ResourceGroupService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/ResourceGroupService.java
@@ -1,0 +1,39 @@
+package org.example.unibooker.domain.resource.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.unibooker.domain.company.model.entity.Companies;
+import org.example.unibooker.domain.company.repository.CompanyRepository;
+import org.example.unibooker.domain.resource.model.ResourceGroupDto;
+import org.example.unibooker.domain.resource.model.ResourceGroups;
+import org.example.unibooker.domain.resource.repository.ResourceGroupRepository;
+import org.example.unibooker.domain.user.model.entity.Users;
+import org.example.unibooker.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ResourceGroupService {
+    private final ResourceGroupRepository resourceGroupRepository;
+    private final UserRepository userRepository;
+    private final CompanyRepository companyRepository;
+
+    public void register(ResourceGroupDto.ResourceGroupRegisterReq dto, Long userId) {
+        // 리소스 그룹 이름 중복 체크 (같은 회사 내 동일 이름 방지)
+        if (resourceGroupRepository.existsByNameAndCompanyId(dto.getName(), dto.getCompanyId())) {
+            throw new IllegalArgumentException("이미 동일한 이름의 서비스 그룹이 존재합니다.");
+        }
+
+        // 기업 엔티티 조회
+        Companies company = companyRepository.findById(dto.getCompanyId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 기업 ID입니다."));
+
+        // 사용자 엔티티 조회
+        Users authUser = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 ID입니다."));
+
+        // DTO → Entity 변환
+        ResourceGroups group = dto.toEntity(authUser, company);
+
+        resourceGroupRepository.save(group);
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

- #14 

<br/>

## 📝 요약(Summary)

리소스 그룹 등록 로직 구현했습니다.
- 리소스 그룹 생성 시 그룹명 중복 확인
- 리소스 그룹 생성 시 기업 ID와 유저 ID가 존재하는지 확인

<br/>

## 📸스크린샷

<img width="1608" height="218" alt="image" src="https://github.com/user-attachments/assets/987e5df0-f822-416b-9e84-8e11bdd70012" />

<br/><br/>

## 💬 공유사항

1. 로그인, 회원가입 기능 구현이 안 되어있어서 리소스 그룹 생성 요청 DTO에 userId를 넣었습니다.
SecurityConfig.java에서도 `.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())` 코드 추가해서 인증 과정을 생략하였습니다.
나중에 구현되면 수정하겠습니다.

2. 리소스 그룹명 중복 확인 기능을 넣었는데 그냥 뺄게요........................................