### PR TITLE
[Feat] 리소스 그룹 목록 조회 로직 구현

### DIFF
--- a/src/main/java/org/example/unibooker/domain/resource/controller/ResourceGroupController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/ResourceGroupController.java
@@ -3,6 +3,7 @@ package org.example.unibooker.domain.resource.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.example.unibooker.common.BaseResponse;
 import org.example.unibooker.domain.resource.model.ResourceGroupDto;
 import org.example.unibooker.domain.resource.repository.ResourceGroupRepository;
 import org.example.unibooker.domain.resource.service.ResourceGroupService;
@@ -22,18 +23,19 @@ public class ResourceGroupController {
     // ---------------- 생성 ----------------
     @Operation(summary = "서비스 그룹 생성", description = "예약/신청 서비스 그룹을 생성합니다.")
     @PostMapping
-    public void register(@RequestBody ResourceGroupDto.ResourceGroupRegisterReq dto) {
+    public BaseResponse register(@RequestBody ResourceGroupDto.ResourceGroupRegisterReq dto) {
         // TODO : 로그인 기능이 개발되면 userId 받아오는 거 수정
         resourceGroupService.register(dto, dto.getUserId());
+        return BaseResponse.success("서비스 그룹이 생성되었습니다.");
     }
 
 
     // ---------------- 목록 조회 ----------------
     @Operation(summary = "특정 기업의 서비스 그룹 목록 조회", description = "특정 기업의 서비스 그룹 목록을 조회합니다.")
     @GetMapping("company/{companyId}")
-    public ResourceGroupDto.ResourceGroupListRes getAllResourceGroups(@PathVariable Long companyId) {
-        // TODO: 서비스 그룹 수정 컨트롤러 구현
-        return ResourceGroupDto.ResourceGroupListRes.builder().resourceGroups(List.of()).build();
+    public BaseResponse<ResourceGroupDto.ResourceGroupListRes> getAllResourceGroups(@PathVariable Long companyId) {
+        ResourceGroupDto.ResourceGroupListRes response = resourceGroupService.getResourceGroupsByCompanyId(companyId);
+        return BaseResponse.success(response);
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceDto.java
@@ -41,7 +41,7 @@ public class ResourceDto {
         private LocalTime endTime;
 
         @Schema(description = "시간 간격", example = "30 또는 60", nullable = true)
-        private int time_interval;
+        private int timeInterval;
 
         @Schema(description = "인원수", example = "4", nullable = true)
         private Integer capacity;
@@ -81,7 +81,7 @@ public class ResourceDto {
         private LocalTime endTime;
 
         @Schema(description = "시간 간격", example = "30 또는 60", nullable = true)
-        private int time_interval;
+        private int timeInterval;
 
         @Schema(description = "인원수", example = "4", nullable = true)
         private Integer capacity;

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceDto.java
@@ -40,6 +40,9 @@ public class ResourceDto {
         @Schema(description = "종료 시간", example = "19:00", nullable = true)
         private LocalTime endTime;
 
+        @Schema(description = "시간 간격", example = "30 또는 60", nullable = true)
+        private int time_interval;
+
         @Schema(description = "인원수", example = "4", nullable = true)
         private Integer capacity;
 
@@ -76,6 +79,9 @@ public class ResourceDto {
 
         @Schema(description = "종료 시간", example = "19:00", nullable = true)
         private LocalTime endTime;
+
+        @Schema(description = "시간 간격", example = "30 또는 60", nullable = true)
+        private int time_interval;
 
         @Schema(description = "인원수", example = "4", nullable = true)
         private Integer capacity;

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroupDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroupDto.java
@@ -80,6 +80,9 @@ public class ResourceGroupDto {
     @Schema(description = "리소스 그룹 상세 조회 응답 DTO")
     public static class ResourceGroupDetailRes {
 
+        @Schema(description = "서비스 그룹 아이디", example = "1")
+        private Long id;
+
         @Schema(description = "서비스 그룹 이름", example = "회의실")
         private String name;
 
@@ -88,6 +91,15 @@ public class ResourceGroupDto {
 
         @Schema(description = "썸네일 URL", example = "https://example.com/thumbnail.jpg")
         private String thumbnail;
+
+        public static ResourceGroupDetailRes fromEntity(ResourceGroups entity) {
+            return ResourceGroupDetailRes.builder()
+                    .id(entity.getId())
+                    .name(entity.getName())
+                    .description(entity.getDescription())
+                    .thumbnail(entity.getThumbnail())
+                    .build();
+        }
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/model/Resources.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/Resources.java
@@ -39,18 +39,24 @@ public class Resources extends BaseEntity {
     private Boolean isActive = true;
 
     /** 예약 시작일 */
-    @Column(nullable = false)
+    @Column(nullable = true)
     private LocalDate startDate;
 
     /** 예약 종료일 */
-    @Column(nullable = false)
+    @Column(nullable = true)
     private LocalDate endDate;
 
     /** 예약 시작 시간 */
+    @Column(nullable = true)
     private LocalTime startTime;
 
     /** 예약 종료 시간 */
+    @Column(nullable = true)
     private LocalTime endTime;
+
+    /** 시간 간격 */
+    @Column(nullable = true)
+    private int timeInterval;
 
     /** 수용 인원 */
     @Column(nullable = false)
@@ -86,4 +92,15 @@ public class Resources extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "updated_by")
     private Users updatedBy;
+
+
+    public void setTimeInterval(TimeIntervalType type) {
+        if (type != null) {
+            this.timeInterval = type.getMinutes();
+        }
+    }
+
+    public TimeIntervalType getTimeIntervalEnum() {
+        return TimeIntervalType.fromMinutes(this.timeInterval);
+    }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/model/TimeIntervalType.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/TimeIntervalType.java
@@ -1,0 +1,26 @@
+package org.example.unibooker.domain.resource.model;
+
+public enum TimeIntervalType {
+    THIRTY(30),
+    SIXTY(60);
+
+    private final int minutes;
+
+    TimeIntervalType(int minutes) {
+        this.minutes = minutes;
+    }
+
+    public int getMinutes() {
+        return minutes;
+    }
+
+    // 숫자로 enum 찾기
+    public static TimeIntervalType fromMinutes(int minutes) {
+        for (TimeIntervalType type : values()) {
+            if (type.getMinutes() == minutes) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Invalid minutes: " + minutes);
+    }
+}

--- a/src/main/java/org/example/unibooker/domain/resource/repository/ResourceGroupRepository.java
+++ b/src/main/java/org/example/unibooker/domain/resource/repository/ResourceGroupRepository.java
@@ -4,7 +4,14 @@ import org.example.unibooker.domain.resource.model.ResourceGroups;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ResourceGroupRepository extends JpaRepository<ResourceGroups, Long> {
-    boolean existsByNameAndCompanyId(String name, Long companyId); // 중복 체크용
+
+    // 기업명 중복 체크용
+    boolean existsByNameAndCompanyId(String name, Long companyId);
+
+    // 특정 기업의 리소스 그룹 조회 (삭제된 거 제외)
+    List<ResourceGroups> findAllByCompanyIdAndDeletedAtIsNull(Long companyId);
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/ResourceGroupService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/ResourceGroupService.java
@@ -10,6 +10,9 @@ import org.example.unibooker.domain.user.model.entity.Users;
 import org.example.unibooker.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class ResourceGroupService {
@@ -17,6 +20,7 @@ public class ResourceGroupService {
     private final UserRepository userRepository;
     private final CompanyRepository companyRepository;
 
+    // -------------------- 리소스 그룹 등록 --------------------
     public void register(ResourceGroupDto.ResourceGroupRegisterReq dto, Long userId) {
         // 리소스 그룹 이름 중복 체크 (같은 회사 내 동일 이름 방지)
         if (resourceGroupRepository.existsByNameAndCompanyId(dto.getName(), dto.getCompanyId())) {
@@ -35,5 +39,23 @@ public class ResourceGroupService {
         ResourceGroups group = dto.toEntity(authUser, company);
 
         resourceGroupRepository.save(group);
+    }
+
+
+    // -------------------- 리소스 그룹 목록 조회 --------------------
+    public ResourceGroupDto.ResourceGroupListRes getResourceGroupsByCompanyId(Long companyId) {
+
+        // 특정 기업(companyId)에 속한 모든 리소스 그룹을 조회
+        List<ResourceGroups> groups = resourceGroupRepository.findAllByCompanyIdAndDeletedAtIsNull(companyId);
+
+        // Entity -> DTO 변환
+        List<ResourceGroupDto.ResourceGroupDetailRes> dtoList = groups.stream()
+                .map(ResourceGroupDto.ResourceGroupDetailRes::fromEntity)
+                .collect(Collectors.toList());
+
+        // List로 만들어서 반환
+        return ResourceGroupDto.ResourceGroupListRes.builder()
+                .resourceGroups(dtoList)
+                .build();
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

- #17 

<br/>

## 📝 요약(Summary)

1.  `Resources` 엔티티에 시간 간격 컬럼 `timeInterval` 추가했습니다.
2. 리소스 그룹 목록 조회 로직 구현했습니다.

<br/>

## 📸스크린샷 

- 현재 DB에 있는 리소스 그룹
   <img width="1554" height="215" alt="image" src="https://github.com/user-attachments/assets/35da7f4d-53cd-4586-affa-2fe54901f190" />

- 리소스 그룹 목록 요청했을 때 응답 결과 (요청경로 예시 : `GET` http://localhost:8080/api/resource-group/company/1)
   <img width="910" height="410" alt="image" src="https://github.com/user-attachments/assets/54d77427-b0b9-4895-93ef-5988e8dc6de8" />


<br/>

## 💬 공유사항

시간 슬롯 템플릿 테이블은 사라지고 그 테이블에 있던 요일은 시간 슬롯 테이블에, 시간 간격을 리소스 테이블에 있습니다.