### PR TITLE
[Feat] 일반 사용자 회원가입 API 구현 #48

### DIFF
--- a/src/main/java/org/example/unibooker/common/BaseResponseStatus.java
+++ b/src/main/java/org/example/unibooker/common/BaseResponseStatus.java
@@ -22,6 +22,7 @@ public enum BaseResponseStatus {
     PASSWORD_MISMATCH(30003, "새 비밀번호와 확인 비밀번호가 일치하지 않습니다."),
     INVALID_USER_STATUS(30004, "유효하지 않은 사용자 상태입니다."),
     INVALID_USER_ROLE(30005, "유효하지 않은 사용자 권한입니다."),
+    DUPLICATE_EMAIL_IN_COMPANY(30006, "해당 기업에 이미 등록된 이메일입니다."),  // ← 추가
 
     // ========== 40000: Company 관련 ==========
     COMPANY_NOT_FOUND(40000, "기업 정보를 찾을 수 없습니다."),

--- a/src/main/java/org/example/unibooker/config/SecurityConfig.java
+++ b/src/main/java/org/example/unibooker/config/SecurityConfig.java
@@ -50,6 +50,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/users/check-email").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/companies/check-slug").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/companies/check-business-number").permitAll()
+                        
+                        // 일반 사용자용 기업 정보 조회 (추가)
+                        .requestMatchers(HttpMethod.GET, "/api/companies/slug/**").permitAll()
 
                         // 승인 상태 조회
                         .requestMatchers(HttpMethod.GET, "/api/users/admin/status").permitAll()

--- a/src/main/java/org/example/unibooker/config/WebMvcConfig.java
+++ b/src/main/java/org/example/unibooker/config/WebMvcConfig.java
@@ -23,7 +23,11 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-                .allowedOrigins("http://localhost:3000", "http://localhost:8080")  // Vue 개발 서버
+                .allowedOrigins(
+                        "http://localhost:3000",
+                        "http://localhost:5173",  // ← 이 줄 추가!
+                        "http://localhost:8080"
+                )
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true)  // Cookie 허용

--- a/src/main/java/org/example/unibooker/domain/company/controller/CompanyController.java
+++ b/src/main/java/org/example/unibooker/domain/company/controller/CompanyController.java
@@ -1,6 +1,7 @@
 package org.example.unibooker.domain.company.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
@@ -80,6 +81,19 @@ public class CompanyController {
             @RequestBody @Valid CompanyDto.ApprovalRequest request) {
 
         CompanyDto.ApprovalResponse response = adminService.rejectCompany(companyId, request.getRejectionReason());
+        return BaseResponse.success(response);
+    }
+
+    /**
+     * Company Slug로 기업 정보 조회 (일반 사용자용)
+     */
+    @Operation(summary = "Company Slug로 기업 정보 조회",
+            description = "Company Slug를 통해 기업 정보를 조회합니다. (일반 사용자 회원가입용)")
+    @GetMapping("/slug/{companySlug}")
+    public BaseResponse<CompanyDto.PublicInfoResponse> getCompanyBySlug(
+            @PathVariable @Schema(description = "Company Slug", example = "company-a") String companySlug) {
+
+        CompanyDto.PublicInfoResponse response = companyService.getCompanyBySlug(companySlug);
         return BaseResponse.success(response);
     }
 }

--- a/src/main/java/org/example/unibooker/domain/company/model/dto/CompanyDto.java
+++ b/src/main/java/org/example/unibooker/domain/company/model/dto/CompanyDto.java
@@ -1,5 +1,6 @@
 package org.example.unibooker.domain.company.model.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
@@ -83,5 +84,28 @@ public class CompanyDto {
         private String serviceUrl;
         private CompanyStatus status;
         private LocalDateTime processedAt;
+    }
+
+    // ========== 일반 사용자용 공개 정보 Response (추가) ==========
+
+    /**
+     * 일반 사용자용 기업 공개 정보
+     */
+    @Getter
+    @Builder
+    @Schema(description = "기업 공개 정보 응답 (일반 사용자용)")
+    public static class PublicInfoResponse {
+
+        @Schema(description = "기업 ID", example = "1")
+        private Long id;
+
+        @Schema(description = "기업명", example = "ABC 회사")
+        private String companyName;
+
+        @Schema(description = "Company Slug", example = "company-a")
+        private String companySlug;
+
+        @Schema(description = "로고 URL", example = "https://example.com/logo.png")
+        private String logoUrl;
     }
 }

--- a/src/main/java/org/example/unibooker/domain/company/service/CompanyService.java
+++ b/src/main/java/org/example/unibooker/domain/company/service/CompanyService.java
@@ -1,8 +1,11 @@
 package org.example.unibooker.domain.company.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.unibooker.common.BaseResponseStatus;
 import org.example.unibooker.common.constants.ReservedSlugs;
+import org.example.unibooker.common.exception.BaseException;
 import org.example.unibooker.domain.company.model.dto.CompanyDto;
+import org.example.unibooker.domain.company.model.entity.Companies;
 import org.example.unibooker.domain.company.repository.CompanyRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -90,5 +93,28 @@ public class CompanyService {
             return false;
         }
         return SLUG_PATTERN.matcher(slug).matches();
+    }
+
+    /**
+     * Company Slug로 기업 정보 조회 (일반 사용자용)
+     */
+    @Transactional(readOnly = true)
+    public CompanyDto.PublicInfoResponse getCompanyBySlug(String companySlug) {
+        // 1. Company Slug로 기업 조회
+        Companies company = companyRepository.findByCompanySlug(companySlug)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.COMPANY_NOT_FOUND));
+
+        // 2. 승인된 기업인지 확인
+        if (!company.isApproved()) {
+            throw new BaseException(BaseResponseStatus.COMPANY_NOT_APPROVED);
+        }
+
+        // 3. 공개 정보 반환
+        return CompanyDto.PublicInfoResponse.builder()
+                .id(company.getId())
+                .companyName(company.getCompanyName())
+                .companySlug(company.getCompanySlug())
+                .logoUrl(company.getLogoUrl())
+                .build();
     }
 }

--- a/src/main/java/org/example/unibooker/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/unibooker/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package org.example.unibooker.domain.user.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -8,10 +9,14 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
 import org.example.unibooker.common.BaseResponse;
+import org.example.unibooker.domain.company.model.dto.CompanyDto;
+import org.example.unibooker.domain.company.service.CompanyService;
 import org.example.unibooker.domain.user.model.dto.UserDto;
 import org.example.unibooker.domain.user.service.UserService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * 일반 사용자 회원 관리 컨트롤러
@@ -148,16 +153,35 @@ public class UserController {
 
     // ========== 이메일 중복 확인 ==========
 
+    // ========== 이메일 중복 확인 (기업별) ==========
+
     /**
-     * 이메일 중복 확인
+     * 이메일 중복 확인 (특정 기업 내에서)
      */
-    @Operation(summary = "이메일 중복 확인",
-            description = "이메일이 이미 사용 중인지 확인합니다. true: 사용 중, false: 사용 가능")
+    @Operation(summary = "이메일 중복 확인 (기업별)",
+            description = "특정 기업 내에서 이메일이 이미 사용 중인지 확인합니다. " +
+                    "true: 해당 기업에서 사용 중, false: 해당 기업에서 사용 가능")
     @GetMapping("/check-email")
     public BaseResponse<Boolean> checkEmail(
+            @RequestParam @Email(message = "올바른 이메일 형식이 아닙니다") String email,
+            @RequestParam @Schema(description = "기업 ID", example = "1") Long companyId) {
+
+        boolean exists = userService.existsByEmailAndCompany(email, companyId);
+        return BaseResponse.success(exists);
+    }
+
+// ========== 이메일로 가입한 모든 기업 조회 (추가) ==========
+
+    /**
+     * 이메일로 가입한 기업 목록 조회
+     */
+    @Operation(summary = "이메일로 가입한 기업 목록 조회",
+            description = "해당 이메일로 가입한 모든 기업의 계정 정보를 조회합니다.")
+    @GetMapping("/accounts")
+    public BaseResponse<List<UserDto.AccountInfo>> getAccountsByEmail(
             @RequestParam @Email(message = "올바른 이메일 형식이 아닙니다") String email) {
 
-        boolean exists = userService.existsByEmail(email);
-        return BaseResponse.success(exists);
+        List<UserDto.AccountInfo> accounts = userService.getAccountsByEmail(email);
+        return BaseResponse.success(accounts);
     }
 }

--- a/src/main/java/org/example/unibooker/domain/user/model/dto/UserDto.java
+++ b/src/main/java/org/example/unibooker/domain/user/model/dto/UserDto.java
@@ -1,10 +1,7 @@
 package org.example.unibooker.domain.user.model.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -40,6 +37,10 @@ public class UserDto {
                 example = "Password123!", required = true)
         private String password;
 
+        @NotNull(message = "기업 ID는 필수입니다")
+        @Schema(description = "가입할 기업 ID (company_id)", example = "1", required = true)
+        private Long companyId;
+
         @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "연락처 형식이 올바르지 않습니다 (010-XXXX-XXXX)")
         @Schema(description = "연락처 (phone) - 010-XXXX-XXXX 형식", example = "010-1234-5678")
         private String phone;
@@ -70,6 +71,9 @@ public class UserDto {
 
         @Schema(description = "이메일 (email)", example = "user@example.com")
         private String email;
+
+        @Schema(description = "소속 기업 ID (company_id)", example = "1")
+        private Long companyId;
 
         @Schema(description = "사용자 권한 (role)", example = "USER")
         private UserRole role;
@@ -300,5 +304,40 @@ public class UserDto {
 
         @Schema(description = "성별 (gender)", example = "MALE")
         private Gender gender;
+    }
+
+    // ========== 계정 정보 Response ==========
+
+    /**
+     * 이메일로 가입한 계정 정보
+     */
+    @Getter
+    @Builder
+    @Schema(description = "이메일로 가입한 계정 정보")
+    public static class AccountInfo {
+
+        @Schema(description = "사용자 ID", example = "1")
+        private Long userId;
+
+        @Schema(description = "이메일", example = "user@example.com")
+        private String email;
+
+        @Schema(description = "이름", example = "홍길동")
+        private String name;
+
+        @Schema(description = "소속 기업 ID", example = "10")
+        private Long companyId;
+
+        @Schema(description = "소속 기업명", example = "ABC 회사")
+        private String companyName;
+
+        @Schema(description = "권한", example = "USER")
+        private UserRole role;
+
+        @Schema(description = "계정 상태", example = "ACTIVE")
+        private UserStatus status;
+
+        @Schema(description = "가입 일시", example = "2025-10-16T14:30:00")
+        private LocalDateTime createdAt;
     }
 }

--- a/src/main/java/org/example/unibooker/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/unibooker/domain/user/repository/UserRepository.java
@@ -27,6 +27,23 @@ public interface UserRepository extends JpaRepository<Users, Long> {
      */
     boolean existsByEmail(String email);
 
+    // ========== 기업별 이메일 중복 확인 ==========
+
+    /**
+     * 이메일과 기업 ID로 사용자 조회
+     */
+    Optional<Users> findByEmailAndCompanyId(String email, Long companyId);
+
+    /**
+     * 특정 기업 내에서 이메일 존재 여부 확인
+     */
+    boolean existsByEmailAndCompanyId(String email, Long companyId);
+
+    /**
+     * 이메일로 모든 사용자 조회 (여러 기업에 가입한 경우)
+     */
+    List<Users> findAllByEmail(String email);
+
     /**
      * 기업 ID와 권한으로 사용자 조회
      */

--- a/src/main/java/org/example/unibooker/domain/user/service/UserService.java
+++ b/src/main/java/org/example/unibooker/domain/user/service/UserService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 사용자 비즈니스 로직 처리 서비스
@@ -34,15 +35,26 @@ public class UserService {
     private final JwtUtil jwtUtil;
 
     /**
-     * 일반 사용자 회원가입
+     * 일반 사용자 회원가입 (기업별)
      */
     @Transactional
     public UserDto.SignUpResponse signUpUser(UserDto.SignUpRequest request) {
-        validateDuplicateEmail(request.getEmail());
+        // 1. 기업 존재 여부 확인
+        Companies company = companyRepository.findById(request.getCompanyId())
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.COMPANY_NOT_FOUND));
 
+        // 2. 기업이 승인된 상태인지 확인
+        if (!company.isApproved()) {
+            throw new BaseException(BaseResponseStatus.COMPANY_NOT_APPROVED);
+        }
+
+        // 3. 해당 기업 내에서 이메일 중복 확인
+        validateDuplicateEmailInCompany(request.getEmail(), request.getCompanyId());
+
+        // 4. 비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(request.getPassword());
 
-        // birthDate, gender 추가
+        // 5. Users 엔티티 생성
         Users user = Users.builder()
                 .email(request.getEmail())
                 .password(encodedPassword)
@@ -50,6 +62,7 @@ public class UserService {
                 .phone(request.getPhone())
                 .birthDate(request.getBirthDate())
                 .gender(request.getGender())
+                .companyId(request.getCompanyId())  // ← 기업 ID 설정
                 .role(UserRole.USER)
                 .status(UserStatus.ACTIVE)
                 .build();
@@ -60,10 +73,60 @@ public class UserService {
                 .id(savedUser.getId())
                 .name(savedUser.getName())
                 .email(savedUser.getEmail())
+                .companyId(savedUser.getCompanyId())  // ← 추가
                 .role(savedUser.getRole())
                 .status(savedUser.getStatus())
                 .createdAt(savedUser.getCreatedAt())
                 .build();
+    }
+
+    /**
+     * 특정 기업 내에서 이메일 중복 확인
+     */
+    private void validateDuplicateEmailInCompany(String email, Long companyId) {
+        if (userRepository.existsByEmailAndCompanyId(email, companyId)) {
+            throw new BaseException(BaseResponseStatus.DUPLICATE_EMAIL_IN_COMPANY);
+        }
+    }
+
+    /**
+     * 특정 기업 내에서 이메일 중복 여부 확인
+     */
+    public boolean existsByEmailAndCompany(String email, Long companyId) {
+        return userRepository.existsByEmailAndCompanyId(email, companyId);
+    }
+
+    /**
+     * 이메일로 가입한 모든 계정 조회
+     */
+    @Transactional(readOnly = true)
+    public List<UserDto.AccountInfo> getAccountsByEmail(String email) {
+        List<Users> users = userRepository.findAllByEmail(email);
+
+        return users.stream()
+                .map(user -> {
+                    // 기업 정보 조회
+                    String companyName = null;
+                    if (user.getCompanyId() != null) {
+                        Companies company = companyRepository.findById(user.getCompanyId())
+                                .orElse(null);
+                        if (company != null) {
+                            companyName = company.getCompanyName();
+                        }
+                    }
+
+                    return UserDto.AccountInfo.builder()
+                            .userId(user.getId())
+                            .email(user.getEmail())
+                            .name(user.getName())
+                            .companyId(user.getCompanyId())
+                            .companyName(companyName)
+                            .role(user.getRole())
+                            .status(user.getStatus())
+                            .createdAt(user.getCreatedAt())
+                            .build();
+                })
+                .toList();
     }
 
     /**


### PR DESCRIPTION


## #️⃣ Issue Number

- #48 

## 📝 요약(Summary)

- Company Slug로 기업 정보 조회 API 추가 (GET /api/companies/slug/{companySlug})
- 일반 사용자 회원가입 API 구현 (POST /api/users/signup)
- 기업별 이메일 중복 확인 API 추가 (GET /api/users/check-email)
- Company Slug 유효성 검증 로직 구현 (형식, 예약어, 중복 체크)
- 승인된 기업만 회원가입 가능하도록 검증 추가
- 기업별 사용자 관리 (companyId 기반)
- CORS 설정 추가 (프론트엔드 연동)
- 응답 상태 코드 추가 (COMPANY_NOT_FOUND, COMPANY_NOT_APPROVED 등)

## 📸스크린샷 (선택)

## 💬 공유사항

- 검토바랍니다.