### PR TITLE
[Feat] 리소스 그룹 상세 조회

### DIFF
--- a/src/main/java/org/example/unibooker/domain/resource/controller/ResourceGroupController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/ResourceGroupController.java
@@ -42,18 +42,18 @@ public class ResourceGroupController {
     // ---------------- 단건 조회 ----------------
     @Operation(summary = "서비스 그룹 상세 조회", description = "특정 서비스 그룹의 이름, 설명, 썸네일 이미지를 조회합니다.")
     @GetMapping("/{resourceGroupId}")
-    public ResourceGroupDto.ResourceGroupDetailRes getResourceGroupById(@PathVariable Long resourceGroupId) {
-        // TODO: 서비스 그룹 수정 컨트롤러 구현
-        return ResourceGroupDto.ResourceGroupDetailRes.builder().build();
+    public BaseResponse<ResourceGroupDto.ResourceGroupDetailRes> getResourceGroupById(@PathVariable Long resourceGroupId) {
+        ResourceGroupDto.ResourceGroupDetailRes response = resourceGroupService.getResourceGroupById(resourceGroupId);
+        return BaseResponse.success(response);
     }
 
 
     // ---------------- 수정용 상세 조회 ----------------
     @Operation(summary = "서비스 그룹 상세 조회(수정용)", description = "특정 서비스 그룹을 생성할 때 입력한 데이터 전체를 조회합니다.")
     @GetMapping("/{resourceGroupId}/edit")
-    public ResourceGroupDto.ResourceGroupUpdateRes getResourceGroupDetailById(@PathVariable Long resourceGroupId) {
-        // TODO: 서비스 그룹 수정 컨트롤러 구현
-        return ResourceGroupDto.ResourceGroupUpdateRes.builder().build();
+    public BaseResponse<ResourceGroupDto.ResourceGroupUpdateRes> getResourceGroupDetailById(@PathVariable Long resourceGroupId) {
+        ResourceGroupDto.ResourceGroupUpdateRes response = resourceGroupService.getResourceGroupUpdateDetail(resourceGroupId);
+        return BaseResponse.success(response);
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroupDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroupDto.java
@@ -72,6 +72,16 @@ public class ResourceGroupDto {
 
         @Schema(description = "상시 모집 여부", example = "true")
         private Boolean isAlwaysAvailable;
+
+        public static ResourceGroupUpdateRes fromEntity(ResourceGroups group) {
+            return ResourceGroupUpdateRes.builder()
+                    .name(group.getName())
+                    .description(group.getDescription())
+                    .thumbnail(group.getThumbnail())
+                    .category(group.getCategory().name())
+                    .isAlwaysAvailable(group.getIsAlwaysAvailable())
+                    .build();
+        }
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/repository/ResourceGroupRepository.java
+++ b/src/main/java/org/example/unibooker/domain/resource/repository/ResourceGroupRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ResourceGroupRepository extends JpaRepository<ResourceGroups, Long> {
@@ -14,4 +15,7 @@ public interface ResourceGroupRepository extends JpaRepository<ResourceGroups, L
 
     // 특정 기업의 리소스 그룹 조회 (삭제된 거 제외)
     List<ResourceGroups> findAllByCompanyIdAndDeletedAtIsNull(Long companyId);
+
+    // 특정 기업의 리소스 그룹 조회 (삭제된 거 제외)
+    Optional<ResourceGroups> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/ResourceGroupService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/ResourceGroupService.java
@@ -9,6 +9,7 @@ import org.example.unibooker.domain.resource.repository.ResourceGroupRepository;
 import org.example.unibooker.domain.user.model.entity.Users;
 import org.example.unibooker.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -57,5 +58,25 @@ public class ResourceGroupService {
         return ResourceGroupDto.ResourceGroupListRes.builder()
                 .resourceGroups(dtoList)
                 .build();
+    }
+
+
+    // -------------------- 리소스 그룹 조회 --------------------
+    @Transactional(readOnly = true)
+    public ResourceGroupDto.ResourceGroupDetailRes getResourceGroupById(Long resourceGroupId) {
+        ResourceGroups group = resourceGroupRepository.findByIdAndDeletedAtIsNull(resourceGroupId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 서비스 그룹이 존재하지 않습니다."));
+
+        return ResourceGroupDto.ResourceGroupDetailRes.fromEntity(group);
+    }
+
+
+    // -------------------- 리소스 그룹 조회 (수정용) --------------------
+    @Transactional(readOnly = true)
+    public ResourceGroupDto.ResourceGroupUpdateRes getResourceGroupUpdateDetail(Long resourceGroupId) {
+        ResourceGroups group = resourceGroupRepository.findByIdAndDeletedAtIsNull(resourceGroupId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 리소스 그룹이 존재하지 않습니다."));
+
+        return ResourceGroupDto.ResourceGroupUpdateRes.fromEntity(group);
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

- #85 

<br />

## 📝 요약(Summary)

- 리소스 그룹 단순 조회 : 그룹명, 설명, 썸네일 이미지
- 리소스 그룹 상세 조회(수정용) : 그룹명, 설명, 썸네일 이미지, 카테고리, 상시모집 여부

<br />

## 📸스크린샷 

- DB에 있는 리소스 그룹 데이터
   <img width="1595" height="211" alt="image" src="https://github.com/user-attachments/assets/d147c8c3-57a4-47fc-b6ea-027f90e19c6e" />

- 리소스 그룹 단순 조회 요청 응답 (요청경로 예시 : `GET` http://localhost:8080/api/resource-group/3)
   <img width="672" height="245" alt="image" src="https://github.com/user-attachments/assets/3a2ab325-b65b-4f88-bbaa-6b2873f4d686" />

- 리소스 그룹 상세 조회 (수정용) 요청 응답 (요청경로 예시 : `GET` http://localhost:8080/api/resource-group/3/edit)
   <img width="621" height="301" alt="image" src="https://github.com/user-attachments/assets/7cd8e07f-e0f6-49bc-817a-bd7d5f7e2a84" />

<br />