### PR TITLE
[Feat] 리소스 그룹 수정

### DIFF
--- a/src/main/java/org/example/unibooker/domain/resource/controller/ResourceGroupController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/ResourceGroupController.java
@@ -60,9 +60,10 @@ public class ResourceGroupController {
     // ---------------- 수정 ----------------
     @Operation(summary = "서비스 그룹 수정", description = "기존의 예약/신청 서비스 그룹을 수정합니다.")
     @PutMapping("/{resourceGroupId}")
-    public void update(@PathVariable Long resourceGroupId,
+    public BaseResponse update(@PathVariable Long resourceGroupId,
                        @RequestBody ResourceGroupDto.ResourceGroupUpdateReq dto) {
-        // TODO: 서비스 그룹 수정 컨트롤러 구현
+        resourceGroupService.updateResourceGroup(resourceGroupId, dto, dto.getUserId());
+        return BaseResponse.success("서비스 그룹이 수정되었습니다.");
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroupDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroupDto.java
@@ -128,6 +128,9 @@ public class ResourceGroupDto {
     @Schema(description = "서비스 그룹 수정 요청 DTO")
     public static class ResourceGroupUpdateReq {
 
+        // TODO : 로그인 기능 개발되면 삭제
+        private Long userId;
+
         @Schema(description = "리소스 그룹 이름", example = "동아리")
         private String name;
 

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroups.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroups.java
@@ -49,4 +49,15 @@ public class ResourceGroups extends BaseEntity {
     // 커스텀 필드
     @OneToMany(mappedBy = "resourceGroup", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CustomFieldDefinitions> customFieldDefinitions = new ArrayList<>();
+
+
+    // 서비스 그룹 수정 함수
+    public void update(String name, String description, String thumbnail, String category, Boolean isAlwaysAvailable, Users updatedBy) {
+        if (name != null) this.name = name;
+        if (description != null) this.description = description;
+        if (thumbnail != null) this.thumbnail = thumbnail;
+        if (category != null) this.category = ServiceCategory.valueOf(category);
+        if (isAlwaysAvailable != null) this.isAlwaysAvailable = isAlwaysAvailable;
+        this.updatedBy = updatedBy;
+    }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/ResourceGroupService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/ResourceGroupService.java
@@ -79,4 +79,24 @@ public class ResourceGroupService {
 
         return ResourceGroupDto.ResourceGroupUpdateRes.fromEntity(group);
     }
+
+
+    // -------------------- 리소스 그룹 수정 --------------------
+    @Transactional
+    public void updateResourceGroup(Long resourceGroupId, ResourceGroupDto.ResourceGroupUpdateReq dto, Long userId) {
+        ResourceGroups resourceGroup = resourceGroupRepository.findById(resourceGroupId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 리소스 그룹이 존재하지 않습니다."));
+
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다."));
+
+        resourceGroup.update(
+                dto.getName(),
+                dto.getDescription(),
+                dto.getThumbnail(),
+                dto.getCategory(),
+                dto.getIsAlwaysAvailable(),
+                user
+        );
+    }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

- #15 

<br/>

## 📝 요약(Summary)

리소스 그룹 수정 로직 작성했습니다.
수정 요청 DTO에 userId 추가해서 수정자 ID도 같이 업데이트 되게 하였습니다. (로그인 기능 개발되면 수정하겠습니다.)

<br/>

## 📸스크린샷

- 수정 전 (id가 2인 사용자가 생성한 리소스 그룹)
   요청경로 예시 : `PUT` http://localhost:8080/api/resource-group/3
   <img width="1562" height="211" alt="image" src="https://github.com/user-attachments/assets/6d35ae91-945a-4cd7-a1bc-fbfe82a9ed21" />

- 수정 후
   <img width="1550" height="187" alt="image" src="https://github.com/user-attachments/assets/4ce9d4b2-ffd3-4d1a-ba2c-d16d355e51b4" />
