### PR TITLE
[Feat] 리소스 그룹 삭제

### DIFF
--- a/src/main/java/org/example/unibooker/common/BaseEntity.java
+++ b/src/main/java/org/example/unibooker/common/BaseEntity.java
@@ -28,4 +28,10 @@ public abstract class BaseEntity {
     private LocalDateTime updatedAt;
 
     private LocalDateTime deletedAt; // Soft delete용
+
+
+    // 공통 soft delete 처리
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/controller/ResourceGroupController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/ResourceGroupController.java
@@ -79,9 +79,9 @@ public class ResourceGroupController {
     // ---------------- 서비스 그룹 카테고리 & 상시 모집 여부 조회 ----------------
     @Operation(summary = "서비스 그룹의 카테고리 & 상시 모집 여부 조회", description = "서비스 생성에 필요한 필수입력 필드 구성을 위한 데이터를 조회합니다.")
     @GetMapping("/{resourceGroupId}/register")
-    public ResourceGroupDto.ServiceRegisterFieldRes getServiceRegisterField(@PathVariable Long resourceGroupId) {
-        // TODO: 서비스 그룹 수정 컨트롤러 구현
-        return ResourceGroupDto.ServiceRegisterFieldRes.builder().build();
+    public BaseResponse<ResourceGroupDto.ServiceRegisterFieldRes> getServiceRegisterField(@PathVariable Long resourceGroupId) {
+        ResourceGroupDto.ServiceRegisterFieldRes response = resourceGroupService.getServiceRegisterField(resourceGroupId);
+        return BaseResponse.success(response);
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/controller/ResourceGroupController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/ResourceGroupController.java
@@ -70,8 +70,9 @@ public class ResourceGroupController {
     // ---------------- 삭제 ----------------
     @Operation(summary = "서비스 그룹 삭제", description = "기존의 예약/신청 서비스 그룹을 삭제합니다.")
     @DeleteMapping("/{resourceGroupId}")
-    public void delete(@PathVariable Long resourceGroupId) {
-        // TODO: 서비스 그룹 삭제 컨트롤러 구현
+    public BaseResponse delete(@PathVariable Long resourceGroupId) {
+        resourceGroupService.deleteResourceGroup(resourceGroupId);
+        return BaseResponse.success("서비스 그룹이 삭제되었습니다.");
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroupDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroupDto.java
@@ -161,5 +161,13 @@ public class ResourceGroupDto {
 
         @Schema(description = "상시 모집 여부", example = "true")
         private Boolean isAlwaysAvailable;
+
+        public static ServiceRegisterFieldRes fromEntity(ResourceGroups entity) {
+            return ServiceRegisterFieldRes.builder()
+                    .name(entity.getName())
+                    .category(entity.getCategory())
+                    .isAlwaysAvailable(entity.getIsAlwaysAvailable())
+                    .build();
+        }
     }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/ResourceGroupService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/ResourceGroupService.java
@@ -114,4 +114,14 @@ public class ResourceGroupService {
         // BaseEntity의 softDelete() 호출
         resourceGroup.softDelete();
     }
+
+
+    // -------------------- 리소스 그룹 삭제 --------------------
+    @Transactional(readOnly = true)
+    public ResourceGroupDto.ServiceRegisterFieldRes getServiceRegisterField(Long resourceGroupId) {
+        ResourceGroups resourceGroup = resourceGroupRepository.findByIdAndDeletedAtIsNull(resourceGroupId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 리소스 그룹이 존재하지 않습니다."));
+
+        return ResourceGroupDto.ServiceRegisterFieldRes.fromEntity(resourceGroup);
+    }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/ResourceGroupService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/ResourceGroupService.java
@@ -99,4 +99,19 @@ public class ResourceGroupService {
                 user
         );
     }
+
+
+    // -------------------- 리소스 그룹 삭제 --------------------
+    @Transactional
+    public void deleteResourceGroup(Long resourceGroupId) {
+        ResourceGroups resourceGroup = resourceGroupRepository.findById(resourceGroupId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 리소스 그룹이 존재하지 않습니다."));
+
+        if (resourceGroup.getDeletedAt() != null) {
+            throw new IllegalArgumentException("이미 삭제된 리소스 그룹입니다.");
+        }
+
+        // BaseEntity의 softDelete() 호출
+        resourceGroup.softDelete();
+    }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

- #16 

<br />

## 📝 요약(Summary)

### 1. 리소스 그룹 삭제 로직 작성했습니다.

### 2. `BaseEntity`에 있는 `deletedAt`에 값 넣는 함수 생성했습니다. 소프트 삭제하실 때 사용하세요!
```
// 공통 soft delete 처리
public void softDelete() {
    this.deletedAt = LocalDateTime.now();
}

// 사용법 : BaseEntity의 softDelete() 호출
resourceGroup.softDelete();
``` 

### 3. 서비스 생성할 때 카테고리 별로 필수 입력 필드가 주어집니다.
   3-1. 어떤 필드가 필요한지 확인하려면 먼저 리소스 그룹이 어떤 카테고리를 가졌고 상시모집인지 아닌지를 확인합니다.
   3-2. `CategoryFieldService`에서 상시모집과 카테고리 값에 따라 값을 달리 조회합니다.

   현재 pr에서는 `3-1`만 구현하였습니다.
   추후에 카테고리 필드 서비스 로직을 구현할 때 합쳐서 정리하겠습니다!

<br />

## 📸스크린샷

- 삭제 전 (`deleted_at`에 값이 비어있음)
   요청경로 예시 : `DELETE` http://localhost:8080/api/resource-group/3
   <img width="1549" height="223" alt="image" src="https://github.com/user-attachments/assets/29266302-15b1-4330-94d2-628cbc653a90" />

- 삭제 후 (`deleted_at`에 값이 채워짐)
   <img width="1566" height="215" alt="image" src="https://github.com/user-attachments/assets/30ed632c-38d4-411e-a43a-5890e4523dfc" />

   