### PR TITLE
[Feat] 서비스 수정

### DIFF
--- a/src/main/java/org/example/unibooker/domain/resource/controller/ResourceController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/ResourceController.java
@@ -2,6 +2,7 @@ package org.example.unibooker.domain.resource.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.unibooker.common.BaseResponse;
 import org.example.unibooker.domain.resource.model.ResourceDto;
@@ -54,8 +55,10 @@ public class ResourceController {
     // ---------------- 수정 ----------------
     @Operation(summary = "서비스 수정", description = "기존의 예약/신청 서비스를 수정합니다.")
     @PutMapping("/{resourceId}")
-    public void update() {
-        // TODO: 서비스 그룹 수정 컨트롤러 구현
+    public BaseResponse update(@PathVariable Long resourceId,
+                               @RequestBody @Valid ResourceDto.ResourceUpdateReq dto) {
+        resourceService.update(resourceId, dto);
+        return BaseResponse.success("서비스가 수정되었습니다.");
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceDto.java
@@ -41,7 +41,7 @@ public class ResourceDto {
         private LocalTime endTime;
 
         @Schema(description = "시간 간격", example = "30 또는 60", nullable = true)
-        private int timeInterval;
+        private Integer timeInterval;
 
         @Schema(description = "인원수", example = "4", nullable = true)
         private Integer capacity;
@@ -52,21 +52,28 @@ public class ResourceDto {
         @Schema(description = "열", example = "4", nullable = true)
         private Integer col;
 
+        // 입력값 검증 함수
+        public void validate() {
+            // 종료일 체크
+            if (endDate != null && endDate.isBefore(LocalDate.now())) {
+                throw new IllegalArgumentException("종료일이 오늘 이전인 리소스는 생성할 수 없습니다.");
+            }
+            // 시작일/종료일 체크
+            if (startDate != null && endDate != null && endDate.isBefore(startDate)) {
+                throw new IllegalArgumentException("종료일은 시작일보다 빠를 수 없습니다.");
+            }
+            // 시작시간/종료시간 체크
+            if (startTime != null && endTime != null && !endTime.isAfter(startTime)) {
+                throw new IllegalArgumentException("종료시간은 시작시간보다 늦어야 합니다.");
+            }
+            // 시간 간격 체크
+            if (timeInterval != null && timeInterval != 30 && timeInterval != 60) {
+                throw new IllegalArgumentException("timeInterval은 30 또는 60만 허용됩니다.");
+            }
+        }
+
         public Resources toEntity(ResourceGroups group) {
             LocalDate today = LocalDate.now();
-
-            // 날짜 유효성 체크
-            if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
-                throw new IllegalArgumentException("시작일은 종료일보다 늦을 수 없습니다.");
-            }
-            if (endDate != null && endDate.isBefore(today)) {
-                throw new IllegalArgumentException("지난 예약 서비스는 생성할 수 없습니다.");
-            }
-            if (startDate != null && endDate != null && startDate.equals(endDate)) {
-                if (startTime != null && endTime != null && !endTime.isAfter(startTime)) {
-                    throw new IllegalArgumentException("종료 시간은 시작 시간보다 늦어야 합니다.");
-                }
-            }
 
             // status 결정
             ResourceStatus status;
@@ -161,6 +168,55 @@ public class ResourceDto {
 
         @Schema(description = "리소스 목록")
         private List<ResourceListInfo> resources;
+    }
+
+
+    @Getter
+    @Builder
+    @Schema(description = "리소스 수정 요청 DTO")
+    public static class ResourceUpdateReq {
+
+        @Schema(description = "서비스 이름", example = "회의실 101")
+        private String name;
+
+        @Schema(description = "서비스 설명", example = "회의실 101 예약용")
+        private String description;
+
+        @Schema(description = "서비스 이미지 URL 목록", example = "[\"https://example.com/img1.jpg\"]")
+        private List<String> resourceImageUrls;
+
+        @Schema(description = "시작 날짜", example = "2025-10-16", nullable = true)
+        private LocalDate startDate;
+
+        @Schema(description = "종료 날짜", example = "2025-10-18", nullable = true)
+        private LocalDate endDate;
+
+        @Schema(description = "시작 시간", example = "12:00", nullable = true)
+        private LocalTime startTime;
+
+        @Schema(description = "종료 시간", example = "19:00", nullable = true)
+        private LocalTime endTime;
+
+        @Schema(description = "시간 간격", example = "30 또는 60", nullable = true)
+        private Integer timeInterval;
+
+        @Schema(description = "인원수", example = "4", nullable = true)
+        private Integer capacity;
+
+        @Schema(description = "행", example = "4", nullable = true)
+        private Integer row;
+
+        @Schema(description = "열", example = "4", nullable = true)
+        private Integer col;
+
+        // 입력값 검증 함수
+        public void validate() {
+            if (timeInterval != null && timeInterval != 30 && timeInterval != 60) {
+                throw new IllegalArgumentException("timeInterval은 30 또는 60만 허용됩니다.");
+            }
+
+            // 필요하다면 다른 필드 검증도 여기에 넣기
+        }
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/model/Resources.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/Resources.java
@@ -94,13 +94,51 @@ public class Resources extends BaseEntity {
     private Users updatedBy;
 
 
-    public void setTimeInterval(TimeIntervalType type) {
-        if (type != null) {
-            this.timeInterval = type.getMinutes();
-        }
+    public void setTimeInterval(int minutes) {
+        this.timeInterval = TimeIntervalType.fromMinutes(minutes).getMinutes();
     }
 
     public TimeIntervalType getTimeIntervalEnum() {
         return TimeIntervalType.fromMinutes(this.timeInterval);
+    }
+
+    // 서비스 수정 함수
+    public void update(ResourceDto.ResourceUpdateReq dto) {
+
+        // 종료일 체크
+        if (dto.getEndDate() != null && dto.getEndDate().isBefore(LocalDate.now())) {
+            throw new IllegalArgumentException("종료일이 오늘 이전인 리소스는 수정할 수 없습니다.");
+        }
+
+        // 시작일/종료일 체크
+        if (dto.getStartDate() != null && dto.getEndDate() != null
+                && dto.getEndDate().isBefore(dto.getStartDate())) {
+            throw new IllegalArgumentException("종료일은 시작일보다 빠를 수 없습니다.");
+        }
+
+        // 시작시간/종료시간 체크
+        if (dto.getStartTime() != null && dto.getEndTime() != null
+                && !dto.getEndTime().isAfter(dto.getStartTime())) {
+            throw new IllegalArgumentException("종료시간은 시작시간보다 늦어야 합니다.");
+        }
+
+        // 상태 결정
+        if (resourceGroup.getIsAlwaysAvailable() || (dto.getStartDate() != null && !dto.getStartDate().isAfter(LocalDate.now()))) {
+            this.status = ResourceStatus.IN_PROGRESS;
+        } else {
+            this.status = ResourceStatus.PROGRESS_BEFORE;
+        }
+
+        // 필드 업데이트 (null 체크)
+        if (dto.getName() != null) this.name = dto.getName();
+        if (dto.getDescription() != null) this.description = dto.getDescription();
+        if (dto.getStartDate() != null) this.startDate = dto.getStartDate();
+        if (dto.getEndDate() != null) this.endDate = dto.getEndDate();
+        if (dto.getStartTime() != null) this.startTime = dto.getStartTime();
+        if (dto.getEndTime() != null) this.endTime = dto.getEndTime();
+        if (dto.getTimeInterval() != null) this.timeInterval = dto.getTimeInterval();
+        if (dto.getCapacity() != null) this.capacity = dto.getCapacity();
+        if (dto.getRow() != null) this.row = dto.getRow();
+        if (dto.getCol() != null) this.col = dto.getCol();
     }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/ResourceService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/ResourceService.java
@@ -9,6 +9,7 @@ import org.example.unibooker.domain.resource.repository.ResourceGroupRepository;
 import org.example.unibooker.domain.resource.repository.ResourceRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -24,12 +25,27 @@ public class ResourceService {
     @Transactional
     public void register(ResourceDto.ResourceRegisterReq dto) {
         // TODO : 생성자, 수정자
+        dto.validate();
 
         ResourceGroups group = resourceGroupRepository.findById(dto.getResourceGroupId())
                 .orElseThrow(() -> new IllegalArgumentException("해당 리소스 그룹이 존재하지 않습니다."));
 
         Resources resource = dto.toEntity(group);
 
+        resource.setTimeInterval(dto.getTimeInterval());
+
         resourceRepository.save(resource);
+    }
+
+
+    // -------------------- 리소스 수정 --------------------
+    @Transactional
+    public void update(Long resourceId, ResourceDto.ResourceUpdateReq dto) {
+        dto.validate();
+
+        Resources resource = resourceRepository.findById(resourceId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 리소스가 존재하지 않습니다."));
+
+        resource.update(dto);
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

- #19 

<br />

## 📝 요약(Summary)

서비스 수정 로직 구현하였습니다.

1. **`Resources` 엔티티에 서비스 수정 함수 `update` 구현**
   - 서비스 코드에서 간단하게 업데이트 진행할 수 있도록 엔티티에 서비스 업데이트 함수를 추가하였습니다.

2. **입력값 검증**
   - 입력값은 엔티티와 DTO 두 차례를 걸쳐서 검증하고 있습니다.
   - 검증하는 부분은 아래와 같습니다.
      - 시작날짜가 종료날짜보다 빠른지
      - 시간 시간이 종료시간보다 빠른지
      - 생성하는 서비스의 종료날짜가 오늘 날짜보다 느린지
      - 시간 간격이 `30`, `60` 중 하나인지

<br />

## 📸스크린샷

- 수정 전 (요청경로 예시 : `PUT` 

   <img width="1129" height="233" alt="스크린샷 2025-10-20 031027" src="https://github.com/user-attachments/assets/eb653aeb-f9de-4478-b954-471d0b0868b5" />

- 수정 후

   <img width="1132" height="240" alt="image" src="https://github.com/user-attachments/assets/ea7cb5c0-4747-45d1-b23f-d33169945e58" />

   시간 간격을 60으로 수정하였고, 서비스 이름과 설명에서 `101`을 `102`로 수정하였습니다.

<br />

## 💬 공유사항

1. 입력값 검증을 엔티티에서도 하고, DTO에서도 하고 있는데 엔티티에서만 하는 게 좋을까요??
2. 이미지 수정 로직은 나중에 추가하겠습니다.
3. 입력값 검증에서 추가해야 할 부분이 있을까요?

<br />