### PR TITLE
[Feat] 서비스 상세 조회

### DIFF
--- a/src/main/java/org/example/unibooker/domain/resource/controller/ResourceController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/ResourceController.java
@@ -30,7 +30,7 @@ public class ResourceController {
 
     // ---------------- 목록 조회 ----------------
     @Operation(summary = "서비스 목록 조회", description = "서비스 목록을 조회합니다.")
-    @GetMapping("/{serviceGroupId}")
+    @GetMapping("/group/{serviceGroupId}")
     public void getAllResources() {
         // TODO: 서비스 그룹 수정 컨트롤러 구현
     }
@@ -39,16 +39,18 @@ public class ResourceController {
     // ---------------- 단건 조회 ----------------
     @Operation(summary = "서비스 상세 조회", description = "서비스를 상세 조회합니다.")
     @GetMapping("/{resourceId}")
-    public void getResourceById() {
-        // TODO: 서비스 그룹 수정 컨트롤러 구현
+    public BaseResponse<ResourceDto.ResourceListInfo> getResourceById(@PathVariable Long resourceId) {
+        ResourceDto.ResourceListInfo response = resourceService.getResourceById(resourceId);
+        return BaseResponse.success(response);
     }
 
 
     // ---------------- 수정용 상세 조회 ----------------
     @Operation(summary = "서비스 상세 조회(수정용)", description = "서비스 생성할 때 입력한 데이터 전체를 조회합니다.")
     @GetMapping("/{resourceGroupId}/edit")
-    public void getResourceDetailById() {
-        // TODO: 서비스 그룹 수정 컨트롤러 구현
+    public BaseResponse<ResourceDto.ResourceUpdateRes> getResourceDetailById(@PathVariable Long resourceGroupId) {
+        ResourceDto.ResourceUpdateRes response = resourceService.getResourceDetailForUpdate(resourceGroupId);
+        return BaseResponse.success(response);
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/controller/ResourceController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/ResourceController.java
@@ -47,9 +47,9 @@ public class ResourceController {
 
     // ---------------- 수정용 상세 조회 ----------------
     @Operation(summary = "서비스 상세 조회(수정용)", description = "서비스 생성할 때 입력한 데이터 전체를 조회합니다.")
-    @GetMapping("/{resourceGroupId}/edit")
-    public BaseResponse<ResourceDto.ResourceUpdateRes> getResourceDetailById(@PathVariable Long resourceGroupId) {
-        ResourceDto.ResourceUpdateRes response = resourceService.getResourceDetailForUpdate(resourceGroupId);
+    @GetMapping("/{resourceId}/edit")
+    public BaseResponse<ResourceDto.ResourceUpdateRes> getResourceDetailById(@PathVariable Long resourceId) {
+        ResourceDto.ResourceUpdateRes response = resourceService.getResourceDetailForUpdate(resourceId);
         return BaseResponse.success(response);
     }
 

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceDto.java
@@ -171,6 +171,9 @@ public class ResourceDto {
     @Schema(description = "리소스 목록 조회 정보 DTO")
     public static class ResourceListInfo {
 
+        @Schema(description = "서비스 아이디", example = "회의실 101")
+        private Long id;
+
         @Schema(description = "서비스 이름", example = "회의실 101")
         private String name;
 
@@ -182,6 +185,7 @@ public class ResourceDto {
 
         public static ResourceListInfo fromEntity(Resources resource) {
             return new ResourceListInfo(
+                    resource.getId(),
                     resource.getName(),
                     resource.getDescription(),
                     resource.getResourceImages() != null && !resource.getResourceImages().isEmpty()

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Schema(description = "서비스 관련 DTO 클래스들")
 public class ResourceDto {
@@ -142,6 +143,26 @@ public class ResourceDto {
 
         @Schema(description = "열", example = "4", nullable = true)
         private Integer col;
+
+        public static ResourceUpdateRes fromEntity(Resources resource) {
+            return new ResourceUpdateRes(
+                    resource.getName(),
+                    resource.getDescription(),
+                    resource.getResourceImages() != null
+                            ? resource.getResourceImages().stream()
+                            .map(img -> img.getResourceImage())
+                            .collect(Collectors.toList())
+                            : null,
+                    resource.getStartDate(),
+                    resource.getEndDate(),
+                    resource.getStartTime(),
+                    resource.getEndTime(),
+                    resource.getTimeInterval(),
+                    resource.getCapacity(),
+                    resource.getRow(),
+                    resource.getCol()
+            );
+        }
     }
 
 
@@ -158,6 +179,16 @@ public class ResourceDto {
 
         @Schema(description = "서비스 이미지 URL", example = "https://example.com/img1.jpg")
         private String resourceImage;
+
+        public static ResourceListInfo fromEntity(Resources resource) {
+            return new ResourceListInfo(
+                    resource.getName(),
+                    resource.getDescription(),
+                    resource.getResourceImages() != null && !resource.getResourceImages().isEmpty()
+                            ? resource.getResourceImages().get(0).getResourceImage()
+                            : null
+            );
+        }
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/repository/ResourceRepository.java
+++ b/src/main/java/org/example/unibooker/domain/resource/repository/ResourceRepository.java
@@ -7,6 +7,4 @@ import java.util.Optional;
 
 public interface ResourceRepository extends JpaRepository<Resources, Long> {
     Optional<Resources> findById(Long resourceId);
-
-    Optional<Resources> findByResourceGroupId(Long resourceGroupId);
 }

--- a/src/main/java/org/example/unibooker/domain/resource/repository/ResourceRepository.java
+++ b/src/main/java/org/example/unibooker/domain/resource/repository/ResourceRepository.java
@@ -3,5 +3,10 @@ package org.example.unibooker.domain.resource.repository;
 import org.example.unibooker.domain.resource.model.Resources;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ResourceRepository extends JpaRepository<Resources, Long> {
+    Optional<Resources> findById(Long resourceId);
+
+    Optional<Resources> findByResourceGroupId(Long resourceGroupId);
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/ResourceService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/ResourceService.java
@@ -38,6 +38,24 @@ public class ResourceService {
     }
 
 
+    // -------------------- 리소스 상세 조회 (수정용) --------------------
+    public ResourceDto.ResourceUpdateRes getResourceDetailForUpdate(Long resourceGroupId) {
+        Resources resource = resourceRepository.findByResourceGroupId(resourceGroupId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 리소스 그룹입니다."));
+
+        return ResourceDto.ResourceUpdateRes.fromEntity(resource);
+    }
+
+
+    // -------------------- 리소스 상세 조회 (목록 조회용) --------------------
+    public ResourceDto.ResourceListInfo getResourceById(Long resourceId) {
+        Resources resource = resourceRepository.findById(resourceId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 리소스입니다."));
+
+        return ResourceDto.ResourceListInfo.fromEntity(resource);
+    }
+
+
     // -------------------- 리소스 수정 --------------------
     @Transactional
     public void update(Long resourceId, ResourceDto.ResourceUpdateReq dto) {

--- a/src/main/java/org/example/unibooker/domain/resource/service/ResourceService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/ResourceService.java
@@ -39,9 +39,9 @@ public class ResourceService {
 
 
     // -------------------- 리소스 상세 조회 (수정용) --------------------
-    public ResourceDto.ResourceUpdateRes getResourceDetailForUpdate(Long resourceGroupId) {
-        Resources resource = resourceRepository.findByResourceGroupId(resourceGroupId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 리소스 그룹입니다."));
+    public ResourceDto.ResourceUpdateRes getResourceDetailForUpdate(Long resourceId) {
+        Resources resource = resourceRepository.findById(resourceId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 리소스입니다."));
 
         return ResourceDto.ResourceUpdateRes.fromEntity(resource);
     }


### PR DESCRIPTION
## #️⃣ Issue Number

- #22 

<br />

## 📝 요약(Summary)

서비스 상세 조회 구현했습니다.
- 서비스 상세 조회 (목록 조회용) : 서비스명, 설명, 대표 이미지
- 서비스 상세 조회 (수정용) : 서비스명, 설명, 이미지, 시작날짜, 종료날짜, 시작시간, 종료시간, 시간간격, 인원수, 행, 열

<br />

## 📸스크린샷

- 서비스 상세 조회 (목록 조회용)

   요청경로 예시 : `GET` http://localhost:8080/api/resource/4

   <img width="522" height="252" alt="image" src="https://github.com/user-attachments/assets/025948eb-0a08-4660-aff8-3a97e5f5c73b" />


- 서비스 상세 조회 (수정용)
 
   요청경로 예시 : `GET` http://localhost:8080/api/resource/4/edit

   <img width="422" height="408" alt="image" src="https://github.com/user-attachments/assets/630ff35d-da0a-46c2-b58a-ea4f6ac31e9b" />


## 💬 공유사항

응답 DTO에 `resource_id` 추가하겠습니다!