### PR TITLE
[Feat] 카테고리 필드 CRUD

### DIFF
--- a/src/main/java/org/example/unibooker/domain/resource/controller/CategoryFieldController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/CategoryFieldController.java
@@ -65,7 +65,8 @@ public class CategoryFieldController {
     // ---------------- 삭제 ----------------
     @Operation(summary = "필드 삭제", description = "필수 입력 필드를 삭제합니다.")
     @DeleteMapping("/{categoryFieldId}")
-    public void delete(@PathVariable Long categoryFieldId) {
-        // TODO
+    public BaseResponse delete(@PathVariable Long categoryFieldId) {
+        categoryFieldService.delete(categoryFieldId);
+        return BaseResponse.success("필드가 삭제되었습니다.");
     }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/controller/CategoryFieldController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/CategoryFieldController.java
@@ -26,24 +26,29 @@ public class CategoryFieldController {
 
 
     // ---------------- 목록 조회 ----------------
-    @Operation(summary = "필드 목록 조회", description = "필수 입력 필드들을 조회합니다.")
+    @Operation(summary = "필드 목록 조회", description = "모든 필수 입력 필드들을 조회합니다.")
     @GetMapping
-    public CategoryFieldDto.CategoryFieldListRes getCategoryFields() {
-        // TODO: service 호출 후 List<CategoryFieldDto.CategoryFieldDetailRes> 생성
-        // 예:
-        // List<CategoryFieldDto.CategoryFieldDetailRes> fields = categoryFieldService.getAll();
-        // return CategoryFieldDto.CategoryFieldListRes.builder().categoryFields(fields).build();
-        return null;
+    public BaseResponse<CategoryFieldDto.CategoryFieldListRes> getCategoryFields() {
+        CategoryFieldDto.CategoryFieldListRes response = categoryFieldService.getAll();
+        return BaseResponse.success(response);
     }
 
 
     // ---------------- 단일 조회 ----------------
     @Operation(summary = "필드 단일 조회", description = "특정 필드를 단일 조회합니다.")
     @GetMapping("/{categoryFieldId}")
-    public CategoryFieldDto.CategoryFieldDetailRes getCategoryField(@PathVariable Long categoryFieldId) {
-        // TODO: service 호출 후 단일 DTO 반환
-        // 예: return categoryFieldService.getDetail(categoryFieldId);
-        return null;
+    public BaseResponse<CategoryFieldDto.CategoryFieldDetailRes> getCategoryField(@PathVariable Long categoryFieldId) {
+        CategoryFieldDto.CategoryFieldDetailRes response = categoryFieldService.getDetail(categoryFieldId);
+        return BaseResponse.success(response);
+    }
+
+
+    // ---------------- 카테고리 별 필드 목록 조회 ----------------
+    @Operation(summary = "카테고리별 필드 목록 조회", description = "특정 카테고리에 속한 필드 목록을 조회합니다.")
+    @GetMapping("/category/{category}")
+    public BaseResponse<CategoryFieldDto.CategoryFieldListRes> getCategoryFieldsByCategory(@PathVariable String category) {
+        CategoryFieldDto.CategoryFieldListRes response = categoryFieldService.getByCategory(category);
+        return BaseResponse.success(response);
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/controller/CategoryFieldController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/CategoryFieldController.java
@@ -55,9 +55,10 @@ public class CategoryFieldController {
     // ---------------- 수정 ----------------
     @Operation(summary = "필드 수정", description = "기존 필드를 수정합니다.")
     @PutMapping("/{categoryFieldId}")
-    public void update(@PathVariable Long categoryFieldId,
+    public BaseResponse update(@PathVariable Long categoryFieldId,
                        @RequestBody CategoryFieldDto.CategoryFieldReq dto) {
-        // TODO
+        categoryFieldService.update(categoryFieldId, dto);
+        return BaseResponse.success("필드가 수정되었습니다.");
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/controller/CategoryFieldController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/CategoryFieldController.java
@@ -3,8 +3,10 @@ package org.example.unibooker.domain.resource.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.example.unibooker.common.BaseResponse;
 import org.example.unibooker.domain.resource.model.CategoryFieldDto;
 import org.example.unibooker.domain.resource.model.ResourceGroupDto;
+import org.example.unibooker.domain.resource.service.CategoryFieldService;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "카테고리별 필수 필드 관리", description = "예약/신청 서비스 그룹의 카테고리별로 가지는 필수 필드를 관리합니다.")
@@ -12,12 +14,14 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/api/category-field")
 public class CategoryFieldController {
+    private final CategoryFieldService categoryFieldService;
 
     // ---------------- 생성 ----------------
     @Operation(summary = "필드 생성", description = "카테고리에 필요한 필수 입력 필드를 생성합니다.")
     @PostMapping
-    public void register(@RequestBody CategoryFieldDto.CategoryFieldReq dto) {
-        // TODO
+    public BaseResponse register(@RequestBody CategoryFieldDto.CategoryFieldReq dto) {
+        categoryFieldService.create(dto);
+        return BaseResponse.success("카테고리 필드가 생성되었습니다.");
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/model/CategoryFieldDefinitions.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/CategoryFieldDefinitions.java
@@ -1,6 +1,9 @@
 package org.example.unibooker.domain.resource.model;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,6 +18,12 @@ import org.example.unibooker.common.BaseEntity;
 public class CategoryFieldDefinitions extends BaseEntity {
     private String fieldName;
     private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private CustomDataType dataType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private ServiceCategory category;
 }

--- a/src/main/java/org/example/unibooker/domain/resource/model/CategoryFieldDefinitions.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/CategoryFieldDefinitions.java
@@ -26,4 +26,11 @@ public class CategoryFieldDefinitions extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ServiceCategory category;
+
+    public void update(CategoryFieldDto.CategoryFieldReq dto) {
+        this.fieldName = dto.getFieldName();
+        this.description = dto.getDescription();
+        this.dataType = dto.getDataType();
+        this.category = dto.getCategory();
+    }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/model/CategoryFieldDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/CategoryFieldDto.java
@@ -25,6 +25,15 @@ public class CategoryFieldDto {
 
         @Schema(description = "필드 적용할 카테고리", example = "RESERVATION")
         private ServiceCategory category;
+
+        public CategoryFieldDefinitions toEntity() {
+            return CategoryFieldDefinitions.builder()
+                    .fieldName(fieldName)
+                    .description(description)
+                    .dataType(dataType)
+                    .category(category)
+                    .build();
+        }
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/model/CategoryFieldDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/CategoryFieldDto.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Schema(description = "카테고리 별 필수 필드 관련 DTO 클래스들")
 public class CategoryFieldDto {
@@ -53,6 +54,15 @@ public class CategoryFieldDto {
 
         @Schema(description = "필드 적용할 카테고리", example = "RESERVATION")
         private ServiceCategory category;
+
+        public static CategoryFieldDetailRes fromEntity(CategoryFieldDefinitions entity) {
+            return CategoryFieldDetailRes.builder()
+                    .fieldName(entity.getFieldName())
+                    .description(entity.getDescription())
+                    .dataType(entity.getDataType())
+                    .category(entity.getCategory())
+                    .build();
+        }
     }
 
 
@@ -63,6 +73,15 @@ public class CategoryFieldDto {
 
         @Schema(description = "카테고리 필드 목록")
         private List<CategoryFieldDetailRes> categoryFields;
+
+        public static CategoryFieldListRes fromEntityList(List<CategoryFieldDefinitions> entities) {
+            List<CategoryFieldDetailRes> list = entities.stream()
+                    .map(CategoryFieldDetailRes::fromEntity)
+                    .collect(Collectors.toList());
+            return CategoryFieldListRes.builder()
+                    .categoryFields(list)
+                    .build();
+        }
     }
 
 }

--- a/src/main/java/org/example/unibooker/domain/resource/repository/CategoryFieldDefinitionRepository.java
+++ b/src/main/java/org/example/unibooker/domain/resource/repository/CategoryFieldDefinitionRepository.java
@@ -1,10 +1,13 @@
 package org.example.unibooker.domain.resource.repository;
 
 import org.example.unibooker.domain.resource.model.CategoryFieldDefinitions;
+import org.example.unibooker.domain.resource.model.ServiceCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CategoryFieldDefinitionRepository extends JpaRepository<CategoryFieldDefinitions, Long> {
-
+    List<CategoryFieldDefinitions> findByCategory(ServiceCategory category);
 }

--- a/src/main/java/org/example/unibooker/domain/resource/repository/CategoryFieldDefinitionRepository.java
+++ b/src/main/java/org/example/unibooker/domain/resource/repository/CategoryFieldDefinitionRepository.java
@@ -1,0 +1,10 @@
+package org.example.unibooker.domain.resource.repository;
+
+import org.example.unibooker.domain.resource.model.CategoryFieldDefinitions;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CategoryFieldDefinitionRepository extends JpaRepository<CategoryFieldDefinitions, Long> {
+
+}

--- a/src/main/java/org/example/unibooker/domain/resource/repository/CategoryFieldDefinitionRepository.java
+++ b/src/main/java/org/example/unibooker/domain/resource/repository/CategoryFieldDefinitionRepository.java
@@ -6,8 +6,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CategoryFieldDefinitionRepository extends JpaRepository<CategoryFieldDefinitions, Long> {
-    List<CategoryFieldDefinitions> findByCategory(ServiceCategory category);
+
+    // 카테고리별 삭제되지 않은 필드 조회
+    List<CategoryFieldDefinitions> findByCategoryAndDeletedAtIsNull(ServiceCategory category);
+
+    // 삭제되지 않은 전체 필드 조회
+    List<CategoryFieldDefinitions> findByDeletedAtIsNull();
+
+    // 삭제되지 않은 단일 필드 조회
+    Optional<CategoryFieldDefinitions> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/CategoryFieldService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/CategoryFieldService.java
@@ -28,14 +28,14 @@ public class CategoryFieldService {
 
     // -------------------- 전체 목록 조회 --------------------
     public CategoryFieldDto.CategoryFieldListRes getAll() {
-        List<CategoryFieldDefinitions> fields = categoryFieldRepository.findAll();
+        List<CategoryFieldDefinitions> fields = categoryFieldRepository.findByDeletedAtIsNull();
         return CategoryFieldDto.CategoryFieldListRes.fromEntityList(fields);
     }
 
 
     // -------------------- 단일 조회 --------------------
     public CategoryFieldDto.CategoryFieldDetailRes getDetail(Long id) {
-        CategoryFieldDefinitions field = categoryFieldRepository.findById(id)
+        CategoryFieldDefinitions field = categoryFieldRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new EntityNotFoundException("해당 필드를 찾을 수 없습니다."));
 
         return CategoryFieldDto.CategoryFieldDetailRes.fromEntity(field);
@@ -45,7 +45,7 @@ public class CategoryFieldService {
     // -------------------- 카테고리 별 목록 조회 --------------------
     public CategoryFieldDto.CategoryFieldListRes getByCategory(String categoryName) {
         ServiceCategory category = ServiceCategory.valueOf(categoryName.toUpperCase());
-        List<CategoryFieldDefinitions> fields = categoryFieldRepository.findByCategory(category);
+        List<CategoryFieldDefinitions> fields = categoryFieldRepository.findByCategoryAndDeletedAtIsNull(category);
         return CategoryFieldDto.CategoryFieldListRes.fromEntityList(fields);
     }
 
@@ -53,9 +53,19 @@ public class CategoryFieldService {
     // ---------------- 수정 ----------------
     @Transactional
     public void update(Long categoryFieldId, CategoryFieldDto.CategoryFieldReq dto) {
-        CategoryFieldDefinitions field = categoryFieldRepository.findById(categoryFieldId)
+        CategoryFieldDefinitions field = categoryFieldRepository.findByIdAndDeletedAtIsNull(categoryFieldId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 필드를 찾을 수 없습니다. ID: " + categoryFieldId));
 
         field.update(dto);
+    }
+
+
+    // ---------------- 삭제 ----------------
+    @Transactional
+    public void delete(Long categoryFieldId) {
+        CategoryFieldDefinitions field = categoryFieldRepository.findByIdAndDeletedAtIsNull(categoryFieldId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 필드를 찾을 수 없습니다. ID: " + categoryFieldId));
+
+        field.softDelete();
     }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/CategoryFieldService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/CategoryFieldService.java
@@ -48,4 +48,14 @@ public class CategoryFieldService {
         List<CategoryFieldDefinitions> fields = categoryFieldRepository.findByCategory(category);
         return CategoryFieldDto.CategoryFieldListRes.fromEntityList(fields);
     }
+
+
+    // ---------------- 수정 ----------------
+    @Transactional
+    public void update(Long categoryFieldId, CategoryFieldDto.CategoryFieldReq dto) {
+        CategoryFieldDefinitions field = categoryFieldRepository.findById(categoryFieldId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 필드를 찾을 수 없습니다. ID: " + categoryFieldId));
+
+        field.update(dto);
+    }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/CategoryFieldService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/CategoryFieldService.java
@@ -1,11 +1,16 @@
 package org.example.unibooker.domain.resource.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.example.unibooker.domain.resource.model.CategoryFieldDefinitions;
 import org.example.unibooker.domain.resource.model.CategoryFieldDto;
+import org.example.unibooker.domain.resource.model.ServiceCategory;
 import org.example.unibooker.domain.resource.repository.CategoryFieldDefinitionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -18,5 +23,29 @@ public class CategoryFieldService {
     public void create(CategoryFieldDto.CategoryFieldReq dto) {
         CategoryFieldDefinitions field = dto.toEntity();
         categoryFieldRepository.save(field);
+    }
+
+
+    // -------------------- 전체 목록 조회 --------------------
+    public CategoryFieldDto.CategoryFieldListRes getAll() {
+        List<CategoryFieldDefinitions> fields = categoryFieldRepository.findAll();
+        return CategoryFieldDto.CategoryFieldListRes.fromEntityList(fields);
+    }
+
+
+    // -------------------- 단일 조회 --------------------
+    public CategoryFieldDto.CategoryFieldDetailRes getDetail(Long id) {
+        CategoryFieldDefinitions field = categoryFieldRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("해당 필드를 찾을 수 없습니다."));
+
+        return CategoryFieldDto.CategoryFieldDetailRes.fromEntity(field);
+    }
+
+
+    // -------------------- 카테고리 별 목록 조회 --------------------
+    public CategoryFieldDto.CategoryFieldListRes getByCategory(String categoryName) {
+        ServiceCategory category = ServiceCategory.valueOf(categoryName.toUpperCase());
+        List<CategoryFieldDefinitions> fields = categoryFieldRepository.findByCategory(category);
+        return CategoryFieldDto.CategoryFieldListRes.fromEntityList(fields);
     }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/CategoryFieldService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/CategoryFieldService.java
@@ -1,0 +1,22 @@
+package org.example.unibooker.domain.resource.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.unibooker.domain.resource.model.CategoryFieldDefinitions;
+import org.example.unibooker.domain.resource.model.CategoryFieldDto;
+import org.example.unibooker.domain.resource.repository.CategoryFieldDefinitionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryFieldService {
+    private final CategoryFieldDefinitionRepository categoryFieldRepository;
+
+
+    // -------------------- 카테고리 필드 생성 --------------------
+    @Transactional
+    public void create(CategoryFieldDto.CategoryFieldReq dto) {
+        CategoryFieldDefinitions field = dto.toEntity();
+        categoryFieldRepository.save(field);
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

- #104 

<br />

## 📝 요약(Summary)

### 1. **카테고리 필드 생성**

   요청경로 예시 : `POST` http://localhost:8080/api/category-field

   <img width="576" height="390" alt="image" src="https://github.com/user-attachments/assets/b843fa65-890c-4286-87d9-1348d47668de" />
   <img width="1090" height="342" alt="image" src="https://github.com/user-attachments/assets/5785f3e5-35be-4a37-b436-c367314b6956" />

### 2. **필드 전체 조회**

   요청경로 예시 : `GET` http://localhost:8080/api/category-field

   <img width="704" height="624" alt="image" src="https://github.com/user-attachments/assets/83fe7c61-3f35-44d3-bf29-588321ea3629" />

### 3.**필드 단일 조회**

   요청경로 예시 : `GET` http://localhost:8080/api/category-field/1

   <img width="529" height="246" alt="image" src="https://github.com/user-attachments/assets/eddb7c3f-8dc1-482f-8d59-25be8369ebb3" />

### 4. **카테고리 별 필드 목록 조회**

   요청경로 예시 : `GET` http://localhost:8080/api/category-field/category/RESERVATION

   <img width="595" height="614" alt="image" src="https://github.com/user-attachments/assets/51ec573f-b1df-438a-9e65-c59fd48caa97" />

### 5. **카테고리 필드 수정**

   요청경로 예시 : `PUT`

   - 수정 전
   
   <img width="1082" height="187" alt="image" src="https://github.com/user-attachments/assets/1d5bb733-a8bd-43dd-9f6a-bb7048fdaae2" />

   - 수정 후

   <img width="1037" height="193" alt="image" src="https://github.com/user-attachments/assets/6a0af541-bf1d-46e7-962e-8cd8a66a4e1e" />

### 6. **카테고리 필드 삭제**
 
   요청경로 예시 : `DELETE` http://localhost:8080/api/category-field/12

   - 삭제 전
   
   <img width="1063" height="188" alt="image" src="https://github.com/user-attachments/assets/e5c42e1d-4700-41a3-bda1-af9f10fbb46d" />

   - 삭제 후

   <img width="1119" height="195" alt="image" src="https://github.com/user-attachments/assets/8003703b-0a95-4bfa-97b9-28de984675eb" />

   `deleted_at`에 삭제 날짜가 저장된 걸 확인할 수 있습니다.

<br />
