### PR TITLE
[Feat] 커스텀 필드 CRUD 구현

### DIFF
--- a/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldController.java
@@ -47,11 +47,12 @@ public class CustomFieldController {
     // ---------------- 필드 수정 ----------------
     @Operation(summary = "커스텀 필드 수정", description = "기존 커스텀 필드를 수정합니다.")
     @PutMapping("/{customFieldId}")
-    public void updateCustomField(
+    public BaseResponse updateCustomField(
             @PathVariable Long customFieldId,
             @RequestBody CustomFieldDto.CustomFieldReq dto
     ) {
-        // TODO
+        customFieldService.update(customFieldId, dto);
+        return BaseResponse.success("커스텀 필드가 수정되었습니다.");
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldController.java
@@ -3,8 +3,10 @@ package org.example.unibooker.domain.resource.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.example.unibooker.common.BaseResponse;
 import org.example.unibooker.domain.resource.model.CustomFieldDto;
-import org.example.unibooker.domain.resource.model.CustomeTargetType;
+import org.example.unibooker.domain.resource.model.CustomTargetType;
+import org.example.unibooker.domain.resource.service.CustomFieldService;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -14,29 +16,31 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/custom-field")
 public class CustomFieldController {
+    private final CustomFieldService customFieldService;
 
     // ---------------- 필드 정의 --------------------
 
     // ---------------- 필드 생성 ----------------
     @Operation(summary = "커스텀 필드 생성", description = "서비스 또는 사용자 커스텀 필드를 생성합니다.")
     @PostMapping("/{resourceGroupId}")
-    public void registerCustomField(
+    public BaseResponse registerCustomField(
             @PathVariable Long resourceGroupId,
             @RequestBody CustomFieldDto.CustomFieldReq dto
     ) {
-        // TODO: 서비스 레이어에서 CustomFieldType 보고 저장
+        customFieldService.create(resourceGroupId, dto);
+        return BaseResponse.success("커스텀 필드가 생성되었습니다.");
     }
 
 
     // ---------------- 필드 조회 ----------------
     @Operation(summary = "커스텀 필드 조회", description = "서비스 그룹의 커스텀 필드 목록을 조회합니다.")
     @GetMapping("/{resourceGroupId}")
-    public List<CustomFieldDto.CustomFieldRes> getCustomFields(
+    public BaseResponse<List<CustomFieldDto.CustomFieldRes>> getCustomFields(
             @PathVariable Long resourceGroupId,
-            @RequestParam(required = false) CustomeTargetType type // SERVICE / USER
+            @RequestParam(required = false) CustomTargetType type // SERVICE / USER / null(전체)
     ) {
-        // TODO: 서비스 레이어에서 type 필터링
-        return List.of();
+        List<CustomFieldDto.CustomFieldRes> fields = customFieldService.getCustomFields(resourceGroupId, type);
+        return BaseResponse.success(fields);
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldController.java
@@ -59,8 +59,9 @@ public class CustomFieldController {
     // ---------------- 필드 삭제 ----------------
     @Operation(summary = "커스텀 필드 삭제", description = "커스텀 필드를 삭제합니다.")
     @DeleteMapping("/{customFieldId}")
-    public void deleteCustomField(@PathVariable Long customFieldId) {
-        // TODO
+    public BaseResponse deleteCustomField(@PathVariable Long customFieldId) {
+        customFieldService.delete(customFieldId);
+        return BaseResponse.success("커스텀 필드가 삭제되었습니다.");
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDefinitions.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDefinitions.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.unibooker.common.BaseEntity;
+import org.hibernate.annotations.Where;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,10 +16,13 @@ import java.util.List;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
+@Where(clause = "deleted_at IS NULL")
 public class CustomFieldDefinitions extends BaseEntity {
-    private CustomeTargetType targetType;
+    @Enumerated(EnumType.STRING)
+    private CustomTargetType targetType;
     private String fieldName;
     private String description;
+    @Enumerated(EnumType.STRING)
     private CustomDataType dataType;
     private Boolean isRequired;
 
@@ -34,4 +38,9 @@ public class CustomFieldDefinitions extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "resource_group_id")
     private ResourceGroups resourceGroup;
+
+
+    public void setResourceGroup(ResourceGroups group) {
+        resourceGroup = group;
+    }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDefinitions.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDefinitions.java
@@ -43,4 +43,12 @@ public class CustomFieldDefinitions extends BaseEntity {
     public void setResourceGroup(ResourceGroups group) {
         resourceGroup = group;
     }
+
+    public void update(CustomFieldDto.CustomFieldReq dto) {
+        this.fieldName = dto.getFieldName();
+        this.description = dto.getDescription();
+        this.dataType = dto.getDataType();
+        this.targetType = dto.getTargetType();
+        this.isRequired = dto.getRequired();
+    }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDto.java
@@ -23,13 +23,23 @@ public class CustomFieldDto {
         private String description;
 
         @Schema(description = "데이터 타입", example = "STRING / NUMBER / DATE")
-        private String dataType;
+        private CustomDataType dataType;
 
         @Schema(description = "필드 유형", example = "SERVICE / USER")
-        private String targetType;
+        private CustomTargetType targetType;
 
         @Schema(description = "필수 여부", example = "true")
         private Boolean required;
+
+        public CustomFieldDefinitions toEntity() {
+            return CustomFieldDefinitions.builder()
+                    .fieldName(fieldName)
+                    .description(description)
+                    .dataType(dataType)
+                    .targetType(targetType)
+                    .isRequired(required)
+                    .build();
+        }
     }
 
 
@@ -51,10 +61,21 @@ public class CustomFieldDto {
         private String dataType;
 
         @Schema(description = "필드 유형", example = "SERVICE / USER")
-        private String fieldType;
+        private String targetType;
 
         @Schema(description = "필수 여부", example = "true")
         private Boolean required;
+
+        public static CustomFieldRes fromEntity(CustomFieldDefinitions entity) {
+            return CustomFieldRes.builder()
+                    .id(entity.getId())
+                    .fieldName(entity.getFieldName())
+                    .dataType(entity.getDataType().name()) // ENUM → 문자열
+                    .targetType(entity.getTargetType().name()) // ENUM → 문자열
+                    .required(entity.getIsRequired())
+                    .description(entity.getDescription())
+                    .build();
+        }
     }
 
 

--- a/src/main/java/org/example/unibooker/domain/resource/model/CustomTargetType.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/CustomTargetType.java
@@ -1,6 +1,6 @@
 package org.example.unibooker.domain.resource.model;
 
-public enum CustomeTargetType {
+public enum CustomTargetType {
     USER,
     RESOURCE
 }

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroupDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroupDto.java
@@ -37,6 +37,9 @@ public class ResourceGroupDto {
         @Schema(description = "기업 ID", example = "1")
         private Long companyId;
 
+        @Schema(description = "커스텀 필드 목록")
+        private List<CustomFieldDto.CustomFieldReq> customFields;
+
         public ResourceGroups toEntity(Users authUser, Companies company) {
            return ResourceGroups.builder()
                     .name(name)

--- a/src/main/java/org/example/unibooker/domain/resource/repository/CustomFieldDefinitionRepository.java
+++ b/src/main/java/org/example/unibooker/domain/resource/repository/CustomFieldDefinitionRepository.java
@@ -1,9 +1,22 @@
 package org.example.unibooker.domain.resource.repository;
 
 import org.example.unibooker.domain.resource.model.CustomFieldDefinitions;
+import org.example.unibooker.domain.resource.model.CustomTargetType;
+import org.example.unibooker.domain.resource.model.ResourceGroups;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CustomFieldDefinitionRepository extends JpaRepository<CustomFieldDefinitions, Long> {
+
+    // 리소스 그룹 내의 삭제되지 않은 커스텀 필드 전체 조회
+    List<CustomFieldDefinitions> findByResourceGroupAndDeletedAtIsNull(ResourceGroups resourceGroup);
+
+    // 리소스 그룹 내의 특정 타겟 타입(SERVICE / USER)의 삭제되지 않은 커스텀 필드 조회
+    List<CustomFieldDefinitions> findByResourceGroupAndTargetTypeAndDeletedAtIsNull(
+            ResourceGroups resourceGroup,
+            CustomTargetType targetType
+    );
 }

--- a/src/main/java/org/example/unibooker/domain/resource/repository/CustomFieldDefinitionRepository.java
+++ b/src/main/java/org/example/unibooker/domain/resource/repository/CustomFieldDefinitionRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CustomFieldDefinitionRepository extends JpaRepository<CustomFieldDefinitions, Long> {
@@ -19,4 +20,7 @@ public interface CustomFieldDefinitionRepository extends JpaRepository<CustomFie
             ResourceGroups resourceGroup,
             CustomTargetType targetType
     );
+
+    // 삭제되지 않은 필드 조회
+    Optional<CustomFieldDefinitions> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldService.java
@@ -53,4 +53,13 @@ public class CustomFieldService {
                 .map(CustomFieldDto.CustomFieldRes::fromEntity)
                 .toList();
     }
+
+
+    // -------------------- 커스텀 필드 수정 --------------------
+    public void update(Long customFieldId, CustomFieldDto.CustomFieldReq dto) {
+        CustomFieldDefinitions field = customFieldRepository.findByIdAndDeletedAtIsNull(customFieldId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않거나 삭제된 커스텀 필드입니다."));
+
+        field.update(dto);
+    }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldService.java
@@ -1,9 +1,56 @@
 package org.example.unibooker.domain.resource.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.unibooker.domain.resource.model.CustomFieldDefinitions;
+import org.example.unibooker.domain.resource.model.CustomFieldDto;
+import org.example.unibooker.domain.resource.model.CustomTargetType;
+import org.example.unibooker.domain.resource.model.ResourceGroups;
+import org.example.unibooker.domain.resource.repository.CustomFieldDefinitionRepository;
+import org.example.unibooker.domain.resource.repository.ResourceGroupRepository;
+import org.example.unibooker.domain.resource.repository.ResourceRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CustomFieldService {
+    private final CustomFieldDefinitionRepository customFieldRepository;
+    private final ResourceGroupRepository resourceGroupRepository;
+
+
+    // -------------------- 커스텀 필드 생성 --------------------
+    public void create(Long resourceGroupId, CustomFieldDto.CustomFieldReq dto) {
+        ResourceGroups group = resourceGroupRepository.findById(resourceGroupId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 서비스 그룹 ID입니다."));
+
+        CustomFieldDefinitions field = dto.toEntity();
+        field.setResourceGroup(group);
+
+        customFieldRepository.save(field);
+    }
+
+
+    // -------------------- 커스텀 필드 조회 --------------------
+    public List<CustomFieldDto.CustomFieldRes> getCustomFields(Long resourceGroupId, CustomTargetType type) {
+        // 리소스 그룹 존재 여부 확인
+        ResourceGroups group = resourceGroupRepository.findById(resourceGroupId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 서비스 그룹입니다."));
+
+        List<CustomFieldDefinitions> fields;
+
+        if (type != null) {
+            // 특정 targetType만 조회
+            fields = customFieldRepository.findByResourceGroupAndTargetTypeAndDeletedAtIsNull(group, type);
+        } else {
+            // 전체 조회
+            fields = customFieldRepository.findByResourceGroupAndDeletedAtIsNull(group);
+        }
+
+        return fields.stream()
+                .map(CustomFieldDto.CustomFieldRes::fromEntity)
+                .toList();
+    }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldService.java
@@ -62,4 +62,14 @@ public class CustomFieldService {
 
         field.update(dto);
     }
+
+
+    // -------------------- 커스텀 필드 삭제 --------------------
+    public void delete(Long customFieldId) {
+        // 삭제할 엔티티 조회 (이미 삭제된 건 제외)
+        CustomFieldDefinitions field = customFieldRepository.findByIdAndDeletedAtIsNull(customFieldId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않거나 이미 삭제된 커스텀 필드입니다."));
+
+        field.softDelete();
+    }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/ResourceGroupService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/ResourceGroupService.java
@@ -5,8 +5,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.unibooker.domain.company.model.entity.Companies;
 import org.example.unibooker.domain.company.repository.CompanyRepository;
+import org.example.unibooker.domain.resource.model.CustomFieldDefinitions;
 import org.example.unibooker.domain.resource.model.ResourceGroupDto;
 import org.example.unibooker.domain.resource.model.ResourceGroups;
+import org.example.unibooker.domain.resource.repository.CustomFieldDefinitionRepository;
 import org.example.unibooker.domain.resource.repository.ResourceGroupRepository;
 import org.example.unibooker.domain.user.model.UserRole;
 import org.example.unibooker.domain.user.model.entity.Users;
@@ -24,6 +26,7 @@ public class ResourceGroupService {
     private final ResourceGroupRepository resourceGroupRepository;
     private final UserRepository userRepository;
     private final CompanyRepository companyRepository;
+    private final CustomFieldDefinitionRepository customFieldRepository;
 
 
     // -------------------- 관리자, 매니저 권한을 가졌는지 확인하는 함수 --------------------
@@ -38,11 +41,6 @@ public class ResourceGroupService {
     @Transactional
     public void register(ResourceGroupDto.ResourceGroupRegisterReq dto, Long userId) {
 
-        // 리소스 그룹 이름 중복 체크 (같은 회사 내 동일 이름 방지)
-        if (resourceGroupRepository.existsByNameAndCompanyId(dto.getName(), dto.getCompanyId())) {
-            throw new IllegalArgumentException("이미 동일한 이름의 서비스 그룹이 존재합니다.");
-        }
-
         // 기업 엔티티 조회
         Companies company = companyRepository.findById(dto.getCompanyId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 기업 ID입니다."));
@@ -53,10 +51,22 @@ public class ResourceGroupService {
 
         checkAdminOrManager(user);
 
-        // DTO → Entity 변환
+        // 서비스 그룹 생성 후
         ResourceGroups group = dto.toEntity(user, company);
-
         resourceGroupRepository.save(group);
+
+        // 커스텀 필드 생성
+        if (dto.getCustomFields() != null && !dto.getCustomFields().isEmpty()) {
+            List<CustomFieldDefinitions> fields = dto.getCustomFields().stream()
+                    .map(fieldDto -> {
+                        CustomFieldDefinitions entity = fieldDto.toEntity();
+                        entity.setResourceGroup(group); // FK 설정
+                        return entity;
+                    })
+                    .toList();
+
+            customFieldRepository.saveAll(fields);
+        }
     }
 
 


### PR DESCRIPTION
## #️⃣ Issue Number

- #108 

<br />

## 📝 요약(Summary)

### 1️⃣ **커스텀 필드 생성**

두 가지 방법으로 커스텀 필드를 생성할 수 있습니다.

- **리소스 그룹과 커스텀 필드를 같이 생성**
   리소스 그룹 생성 요청할 때 커스텀 필드 데이터를 같이 넘겨주면 됩니다. (따로 생성 요청할 필요X)
   요청경로 예시 : `POST` http://localhost:8080/api/resource-group
```
{
  "userId": 2,
  "name": "회의실 예약 서비스",
  "description": "회의실 예약 관련 서비스 그룹",
  "thumbnail": "https://example.com/thumbnail.jpg",
  "category": "RESERVATION",
  "isAlwaysAvailable": true,
  "companyId": 1,
  "customFields": [
    {
      "fieldName": "회의실 이름",
      "description": "예약하려는 회의실의 이름",
      "dataType": "TEXT",
      "targetType": "RESOURCE",
      "required": true
    },
    {
      "fieldName": "회의 일시",
      "description": "회의가 진행되는 날짜와 시간",
      "dataType": "DATE",
      "targetType": "RESOURCE",
      "required": true
    }
  ]
}
```

- **커스텀 필드만 따로 생성**
   요청 경로에 리소스 그룹 아이디를 넣어주면 원하는 리소스 그룹에 커스텀 필드를 추가할 수 있습니다.
   요청경로 예시 : `POST` http://localhost:8080/api/custom-field/6
```
{
  "fieldName": "부서명",
  "description": "회의실을 사용하는 부서 이름을 입력해주세요.",
  "dataType": "TEXT",
  "targetType": "USER",
  "required": true
}
```

### 2️⃣ **커스텀 필드 조회**

커스텀 필드 조회는 3가지로 나뉘며 구분은 `type` 파라미터로 합니다.

특정 서비스 그룹에 대해서

- 모든 커스텀 필드 조회 : `GET` http://localhost:8080/api/custom-field/6
- 사용자에게 입력받는 커스텀 필드만 조회 : `GET` http://localhost:8080/api/custom-field/6?type=USER
- 리소스 정보에 대한 (관리자가 입력하는) 커스텀 필드만 조회 : `GET` http://localhost:8080/api/custom-field/6?type=RESOURCE

### 3️⃣ **커스텀 필드 수정**

커스텀 생성과 DTO가 동일해서 생성 DTO를 재사용 했어요...
요청경로 예시 : `PUT` http://localhost:8080/api/custom-field/2

### 4️⃣ **커스텀 필드 삭제**

소프트 삭제 적용했습니다.
요청경로 예시 : `DELETE` http://localhost:8080/api/custom-field/3

<br />

## 📸스크린샷

### 1️⃣ **커스텀 필드 생성**

<img width="1113" height="242" alt="image" src="https://github.com/user-attachments/assets/69c50609-3a8b-4786-af8b-377205063e92" />

### 2️⃣ **커스텀 필드 조회**

- 특정 서비스 그룹의 모든 커스텀 필드 조회

   <img width="550" height="630" alt="image" src="https://github.com/user-attachments/assets/9a1ea8bd-c8ab-4420-927e-a56f83165e35" />

- 특정 서비스 그룹의 USER 커스텀 필드 조회

   <img width="625" height="270" alt="image" src="https://github.com/user-attachments/assets/91b90b50-0e80-4a4a-be29-8fea474040ac" />

- 특정 서비스 그룹의 RESOURCE 커스텀 필드 조회

   <img width="548" height="458" alt="image" src="https://github.com/user-attachments/assets/38682a55-17a4-440a-a050-0e3fece35962" />

### 3️⃣ **커스텀 필드 수정**

- 수정 전

   <img width="1117" height="30" alt="image" src="https://github.com/user-attachments/assets/5b1c0f86-6c80-4dfb-a1b4-eed25967fc89" />

- 수정 후

   <img width="1108" height="28" alt="image" src="https://github.com/user-attachments/assets/7074bb60-3f55-46bc-a2cf-a145cafdadb7" />

### 4️⃣ **커스텀 필드 삭제**

- 삭제 전

   <img width="1115" height="50" alt="image" src="https://github.com/user-attachments/assets/a9e20d57-5212-4ef6-8225-f7848458cbd7" />

- 삭제 후

   <img width="1125" height="55" alt="image" src="https://github.com/user-attachments/assets/f38c6b47-231c-4e23-9c37-4b96a481bd12" />


<br />