### PR TITLE
[FEAT] 관리자 첫 로그인 비밀번호 재설정 API 구현

### DIFF
--- a/src/main/java/org/example/unibooker/common/BaseResponseStatus.java
+++ b/src/main/java/org/example/unibooker/common/BaseResponseStatus.java
@@ -26,6 +26,8 @@ public enum BaseResponseStatus {
     DELETED_USER(30007, "삭제된 계정입니다."),
     INACTIVE_USER(30008, "비활성화된 계정입니다."),
     SUSPENDED_USER(30009, "정지된 계정입니다."),
+    SAME_PASSWORD(30010, "새 비밀번호는 현재 비밀번호와 달라야 합니다."),
+    CURRENT_PASSWORD_INCORRECT(30011, "현재 비밀번호가 일치하지 않습니다."),
 
     // ========== 40000: Company 관련 ==========
     COMPANY_NOT_FOUND(40000, "기업 정보를 찾을 수 없습니다."),

--- a/src/main/java/org/example/unibooker/domain/user/controller/AdminController.java
+++ b/src/main/java/org/example/unibooker/domain/user/controller/AdminController.java
@@ -2,6 +2,8 @@ package org.example.unibooker.domain.user.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
@@ -68,15 +70,36 @@ public class AdminController {
     /**
      * 로그인
      * - UserService의 공통 로그인 로직 사용
+     * - JWT 토큰을 HTTP-Only 쿠키로 설정
      */
     @Operation(summary = "로그인",
             description = "관리자 이메일과 비밀번호로 로그인합니다.")
     @PostMapping("/login")
     public BaseResponse<UserDto.LoginResponse> login(
-            @RequestBody @Valid AdminDto.AdminLoginRequest request) {
+            @RequestBody @Valid AdminDto.AdminLoginRequest request,
+            HttpServletResponse response) {  // ← HttpServletResponse 추가
 
-        UserDto.LoginResponse response = adminService.adminLogin(request);;
-        return BaseResponse.success(response);
+        UserDto.LoginResponse loginResponse = adminService.adminLogin(request);
+
+        // ===== JWT 토큰을 HTTP-Only 쿠키로 설정 =====
+
+        // Access Token 쿠키 설정 (15분)
+        Cookie accessTokenCookie = new Cookie("accessToken", loginResponse.getAccessToken());
+        accessTokenCookie.setHttpOnly(true);  // XSS 방어
+        accessTokenCookie.setSecure(false);   // HTTPS에서만 전송 (개발 환경: false, 프로덕션: true)
+        accessTokenCookie.setPath("/");
+        accessTokenCookie.setMaxAge(15 * 60);  // 15분
+        response.addCookie(accessTokenCookie);
+
+        // Refresh Token 쿠키 설정 (7일)
+        Cookie refreshTokenCookie = new Cookie("refreshToken", loginResponse.getRefreshToken());
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(false);   // 개발 환경: false, 프로덕션: true
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge(7 * 24 * 60 * 60);  // 7일
+        response.addCookie(refreshTokenCookie);
+
+        return BaseResponse.success(loginResponse);
     }
 
     /**
@@ -95,18 +118,19 @@ public class AdminController {
     }
 
     /**
-     * 비밀번호 변경
-     * - UserService의 공통 비밀번호 변경 로직 사용
+     * 비밀번호 재설정 (첫 로그인 시 필수)
+     * - 임시 비밀번호 검증 후 새 비밀번호로 변경
+     * - isFirstLogin 플래그 해제
      */
-    @Operation(summary = "비밀번호 변경",
-            description = "관리자 비밀번호를 변경합니다. 첫 로그인 시 필수입니다.")
-    @PutMapping("/password")
-    public BaseResponse<String> changePassword(
-            @RequestBody @Valid UserDto.PasswordChangeRequest request,
+    @Operation(summary = "비밀번호 재설정",
+            description = "첫 로그인 시 임시 비밀번호를 새 비밀번호로 변경합니다.")
+    @PatchMapping("/password/reset")
+    public BaseResponse<AdminDto.PasswordResetResponse> resetPassword(
+            @RequestBody @Valid AdminDto.PasswordResetRequest request,
             @AuthenticationPrincipal Long userId) {
 
-        userService.changePassword(userId, request);
-        return BaseResponse.success("비밀번호가 성공적으로 변경되었습니다.");
+        AdminDto.PasswordResetResponse response = adminService.resetPassword(userId, request);
+        return BaseResponse.success(response);
     }
 
     /**

--- a/src/main/java/org/example/unibooker/domain/user/model/dto/AdminDto.java
+++ b/src/main/java/org/example/unibooker/domain/user/model/dto/AdminDto.java
@@ -214,6 +214,50 @@ public class AdminDto {
         }
     }
 
+    // ========== 비밀번호 재설정 Request ==========
+
+    /**
+     * 비밀번호 재설정 요청 DTO
+     */
+    @Getter
+    @NoArgsConstructor
+    @Schema(description = "비밀번호 재설정 요청")
+    public static class PasswordResetRequest {
+
+        @NotBlank(message = "현재 비밀번호를 입력해주세요.")
+        @Schema(description = "현재 비밀번호 (임시 비밀번호)", example = "TempPass123!", required = true)
+        private String currentPassword;
+
+        @NotBlank(message = "새 비밀번호를 입력해주세요.")
+        @Pattern(
+                regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
+                message = "비밀번호는 8자 이상, 영문 대소문자, 숫자, 특수문자를 포함해야 합니다."
+        )
+        @Schema(description = "새 비밀번호", example = "NewSecure123!@", required = true)
+        private String newPassword;
+
+        @NotBlank(message = "새 비밀번호 확인을 입력해주세요.")
+        @Schema(description = "새 비밀번호 확인", example = "NewSecure123!@", required = true)
+        private String confirmPassword;
+    }
+
+// ========== 비밀번호 재설정 Response ==========
+
+    /**
+     * 비밀번호 재설정 응답 DTO
+     */
+    @Getter
+    @Builder
+    @Schema(description = "비밀번호 재설정 응답")
+    public static class PasswordResetResponse {
+
+        @Schema(description = "응답 메시지", example = "비밀번호가 성공적으로 변경되었습니다.")
+        private String message;
+
+        @Schema(description = "비밀번호 변경 필요 여부", example = "false")
+        private Boolean passwordChangeRequired;
+    }
+
     // ========== 관리자/매니저 상태 변경 Request (신규) ==========
 
     /**

--- a/src/main/java/org/example/unibooker/domain/user/service/AdminService.java
+++ b/src/main/java/org/example/unibooker/domain/user/service/AdminService.java
@@ -44,6 +44,8 @@ public class AdminService {
     private final Approval approvalService;
     private final ManagerManagement managerManagement;
     private final AuthService authService;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     /**
      * AdminService 생성자 (DI)
@@ -55,6 +57,9 @@ public class AdminService {
                         EmailService emailService,
                         AuthService authService,
                         @Value("${app.base-url:http://localhost:5173}") String baseUrl) {
+
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
         this.signUpService = new SignUp(userRepository, companyRepository, passwordEncoder, fileUploadUtil);
         this.approvalService = new Approval(companyRepository, userRepository, passwordEncoder, emailService, baseUrl);
         this.managerManagement = new ManagerManagement(userRepository, companyRepository, passwordEncoder, emailService);
@@ -431,6 +436,50 @@ public class AdminService {
                 characters[j] = temp;
             }
             return new String(characters);
+        }
+
+        /**
+         * 비밀번호 재설정
+         * - 임시 비밀번호 검증
+         * - 새 비밀번호 유효성 검증
+         * - 비밀번호 변경 및 isFirstLogin 플래그 해제
+         */
+        @Transactional
+        public AdminDto.PasswordResetResponse resetPassword(Long userId, AdminDto.PasswordResetRequest request) {
+            // 1. 사용자 조회
+            Users user = userRepository.findById(userId)
+                    .orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
+
+            // 2. 현재 비밀번호 검증 (임시 비밀번호 확인)
+            if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
+                throw new BaseException(BaseResponseStatus.CURRENT_PASSWORD_INCORRECT); // 30011
+            }
+
+            // 3. 새 비밀번호와 확인 비밀번호 일치 여부 확인
+            if (!request.getNewPassword().equals(request.getConfirmPassword())) {
+                throw new BaseException(BaseResponseStatus.PASSWORD_MISMATCH); // ← 30003 사용!
+            }
+
+            // 4. 새 비밀번호가 현재 비밀번호와 동일한지 확인
+            if (passwordEncoder.matches(request.getNewPassword(), user.getPassword())) {
+                throw new BaseException(BaseResponseStatus.SAME_PASSWORD); // 30010
+            }
+
+            // 5. 비밀번호 암호화
+            String encodedPassword = passwordEncoder.encode(request.getNewPassword());
+
+            // 6. 비밀번호 업데이트 + isFirstLogin 플래그 해제
+            user.updatePassword(encodedPassword);
+            user.completeFirstLogin();
+
+            // 7. 명시적 저장
+            userRepository.save(user);
+
+            // 8. 응답 생성
+            return AdminDto.PasswordResetResponse.builder()
+                    .message("비밀번호가 성공적으로 변경되었습니다.")
+                    .passwordChangeRequired(false)
+                    .build();
         }
 
         /**
@@ -891,5 +940,13 @@ public class AdminService {
      */
     public void updateAdminStatus(Long userId, AdminDto.AdminStatusUpdateRequest request) {
         managerManagement.updateAdminStatus(userId, request);
+    }
+
+    /**
+     * 비밀번호 재설정
+     * - Approval 클래스의 resetPassword 메서드에 위임
+     */
+    public AdminDto.PasswordResetResponse resetPassword(Long userId, AdminDto.PasswordResetRequest request) {
+        return approvalService.resetPassword(userId, request);
     }
 }


### PR DESCRIPTION


## #️⃣ Issue Number

- #49 

## 📝 요약(Summary)

- AdminDto에 PasswordResetRequest, PasswordResetResponse 추가
- AdminController에 PATCH /api/admins/password/reset 엔드포인트 추가
- AdminService에 resetPassword() 메서드 구현
- BaseResponseStatus에 비밀번호 관련 에러 코드 추가
- AdminController login()에 JWT HTTP-Only 쿠키 설정 로직 추가

## 📸스크린샷 (선택)

## 💬 공유사항
