### PR TITLE
[Feat] 커스텀 필드 조회 로직 구현

### DIFF
--- a/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldValueController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldValueController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.unibooker.common.BaseResponse;
 import org.example.unibooker.domain.resource.model.CustomFieldDto;
+import org.example.unibooker.domain.resource.model.CustomTargetType;
 import org.example.unibooker.domain.resource.service.CustomFieldService;
 import org.example.unibooker.domain.resource.service.CustomFieldValueService;
 import org.springframework.web.bind.annotation.*;
@@ -27,13 +28,21 @@ public class CustomFieldValueController {
         return BaseResponse.success("커스텀 필드 값이 생성되었습니다.");
     }
 
-    @Operation(summary = "커스텀 필드 값 조회", description = "커스텀 필드에 대한 값을 조회합니다.")
-    @GetMapping("/value/{customFieldValueId}")
-    public CustomFieldDto.CustomFieldValueListRes getCustomFieldValue(@PathVariable Long customFieldValueId) {
-        // TODO
-        return null;
+
+    // ---------------- 필드 값 조회 --------------------
+    @Operation(summary = "특정 리소스의 커스텀 필드 값 조회",
+            description = "특정 리소스에 대한 커스텀 필드 값을 조회합니다. targetType이 없으면 전체 조회합니다.")
+    @GetMapping("/value/{targetId}")
+    public BaseResponse<List<CustomFieldDto.CustomFieldValueListRes>> getCustomFieldValues(
+            @PathVariable Long targetId,
+            @RequestParam(required = false) CustomTargetType targetType // USER / RESOURCE / null
+    ) {
+        List<CustomFieldDto.CustomFieldValueListRes> response = customFieldValueService.getCustomFieldValues(targetId, targetType);
+        return BaseResponse.success(response);
     }
 
+
+    // ---------------- RESOURCE 필드 값 수정 --------------------
     @Operation(summary = "커스텀 필드 값 수정", description = "커스텀 필드 값을 수정합니다.")
     @PutMapping("/value/{customFieldValueId}")
     public void updateCustomFieldValue(

--- a/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDto.java
@@ -84,7 +84,7 @@ public class CustomFieldDto {
 
     @Getter
     @Builder
-    @Schema(description = "커스텀 필드 값 생성 & 수정 & 조회 요청 DTO")
+    @Schema(description = "커스텀 필드 값 생성 DTO")
     public static class CustomFieldValue {
 
         @Schema(description = "대상 리소스 ID 또는 사용자 ID", example = "101")
@@ -116,10 +116,37 @@ public class CustomFieldDto {
 
     @Getter
     @Builder
-    @Schema(description = "커스텀 필드 값 목록 조회 응답 DTO")
-    public static class CustomFieldValueListRes  {
+    @Schema(description = "커스텀 필드 값 조회 응답 DTO")
+    public static class CustomFieldValueListRes {
 
-        @Schema(description = "커스텀 필드 값 목록")
-        private List<CustomFieldValue> customFieldValues;
+        @Schema(description = "필드 ID", example = "1")
+        private Long customFieldId;
+
+        @Schema(description = "필드 이름", example = "회의실 이름")
+        private String fieldName;
+
+        @Schema(description = "값", example = "101호 회의실")
+        private String value;
+
+        @Schema(description = "타겟 타입", example = "USER / RESOURCE")
+        private CustomTargetType targetType;
+
+        public static CustomFieldValueListRes fromUserEntity(UserCustomFieldValues entity) {
+            return CustomFieldValueListRes.builder()
+                    .customFieldId(entity.getCustomFieldDefinition().getId())
+                    .fieldName(entity.getCustomFieldDefinition().getFieldName())
+                    .value(entity.getFieldValue())
+                    .targetType(CustomTargetType.USER)
+                    .build();
+        }
+
+        public static CustomFieldValueListRes fromResourceEntity(ResourceCustomFieldValues entity) {
+            return CustomFieldValueListRes.builder()
+                    .customFieldId(entity.getCustomFieldDefinition().getId())
+                    .fieldName(entity.getCustomFieldDefinition().getFieldName())
+                    .value(entity.getFieldValue())
+                    .targetType(CustomTargetType.RESOURCE)
+                    .build();
+        }
     }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/repository/ResourceCustomFieldValueRepository.java
+++ b/src/main/java/org/example/unibooker/domain/resource/repository/ResourceCustomFieldValueRepository.java
@@ -4,6 +4,9 @@ import org.example.unibooker.domain.resource.model.ResourceCustomFieldValues;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ResourceCustomFieldValueRepository extends JpaRepository<ResourceCustomFieldValues, Long> {
+    List<ResourceCustomFieldValues> findByResourceIdAndDeletedAtIsNull(Long resourceId);
 }

--- a/src/main/java/org/example/unibooker/domain/resource/repository/UserCustomFieldValueRepository.java
+++ b/src/main/java/org/example/unibooker/domain/resource/repository/UserCustomFieldValueRepository.java
@@ -4,6 +4,9 @@ import org.example.unibooker.domain.resource.model.UserCustomFieldValues;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface UserCustomFieldValueRepository extends JpaRepository<UserCustomFieldValues, Long> {
+    List<UserCustomFieldValues> findByReservationIdAndDeletedAtIsNull(Long reservationId);
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldValueService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldValueService.java
@@ -4,10 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.example.unibooker.domain.resource.model.*;
 import org.example.unibooker.domain.resource.repository.CustomFieldDefinitionRepository;
 import org.example.unibooker.domain.resource.repository.ResourceCustomFieldValueRepository;
+import org.example.unibooker.domain.resource.repository.ResourceRepository;
 import org.example.unibooker.domain.resource.repository.UserCustomFieldValueRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -17,6 +19,7 @@ public class CustomFieldValueService {
     private final CustomFieldDefinitionRepository customFieldRepository;
     private final UserCustomFieldValueRepository userFieldRepository;
     private final ResourceCustomFieldValueRepository resourceFieldRepository;
+    private final ResourceRepository resourceRepository;
 
 
     // -------------------- 커스텀 필드 값 저장 -------------------
@@ -37,5 +40,61 @@ public class CustomFieldValueService {
                 throw new IllegalArgumentException("알 수 없는 타겟 타입입니다. fieldId=" + dto.getCustomFieldId());
             }
         }
+    }
+
+
+    // -------------------- 커스텀 필드 값 조회 -------------------
+    public List<CustomFieldDto.CustomFieldValueListRes> getCustomFieldValues(Long targetId, CustomTargetType targetType) {
+
+        // TODO : 예약 ID 존재 여부 검증하는 서비스 코드가 생기면 레포지토리를 서비스로 변경 후 주석 해제
+        // targetId 존재 여부 검증
+//        boolean exists;
+//        if (targetType == null) {
+//            // 전체 조회 시 — 두 테이블 중 하나라도 존재해야 함
+//            exists = resourceRepository.existsById(targetId) || reservationRepository.existsById(targetId);
+//        } else if (targetType == CustomTargetType.RESOURCE) {
+//            exists = resourceRepository.existsById(targetId);
+//        } else if (targetType == CustomTargetType.USER) {
+//            exists = reservationRepository.existsById(targetId);
+//        } else {
+//            throw new IllegalArgumentException("유효하지 않은 targetType입니다.");
+//        }
+//
+//        if (!exists) {
+//            throw new IllegalArgumentException("존재하지 않는 targetId입니다. id=" + targetId);
+//        }
+
+        List<CustomFieldDto.CustomFieldValueListRes> result = new ArrayList<>();
+
+        if (targetType == null) {
+            // 전체 조회 (USER + RESOURCE)
+            result.addAll(
+                    userFieldRepository.findByReservationIdAndDeletedAtIsNull(targetId)
+                            .stream()
+                            .map(CustomFieldDto.CustomFieldValueListRes::fromUserEntity)
+                            .toList()
+            );
+
+            result.addAll(
+                    resourceFieldRepository.findByResourceIdAndDeletedAtIsNull(targetId)
+                            .stream()
+                            .map(CustomFieldDto.CustomFieldValueListRes::fromResourceEntity)
+                            .toList()
+            );
+
+        } else if (targetType == CustomTargetType.USER) {
+            result = userFieldRepository.findByReservationIdAndDeletedAtIsNull(targetId)
+                    .stream()
+                    .map(CustomFieldDto.CustomFieldValueListRes::fromUserEntity)
+                    .toList();
+
+        } else if (targetType == CustomTargetType.RESOURCE) {
+            result = resourceFieldRepository.findByResourceIdAndDeletedAtIsNull(targetId)
+                    .stream()
+                    .map(CustomFieldDto.CustomFieldValueListRes::fromResourceEntity)
+                    .toList();
+        }
+
+        return result;
     }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldValueService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldValueService.java
@@ -66,15 +66,18 @@ public class CustomFieldValueService {
 
         List<CustomFieldDto.CustomFieldValueListRes> result = new ArrayList<>();
 
+        // targetType이 null일 경우 → USER + RESOURCE 모두 조회
         if (targetType == null) {
-            // 전체 조회 (USER + RESOURCE)
-            result.addAll(
-                    userFieldRepository.findByReservationIdAndDeletedAtIsNull(targetId)
-                            .stream()
-                            .map(CustomFieldDto.CustomFieldValueListRes::fromUserEntity)
-                            .toList()
-            );
+            // USER 필드값: 해당 리소스에 연결된 예약들의 값
+//            List<Long> reservationIds = reservationRepository.findIdsByResourceId(targetId);
+//            result.addAll(
+//                    userFieldRepository.findByReservationIdInAndDeletedAtIsNull(reservationIds)
+//                            .stream()
+//                            .map(CustomFieldDto.CustomFieldValueListRes::fromUserEntity)
+//                            .toList()
+//            );
 
+            // RESOURCE 필드값
             result.addAll(
                     resourceFieldRepository.findByResourceIdAndDeletedAtIsNull(targetId)
                             .stream()
@@ -82,19 +85,27 @@ public class CustomFieldValueService {
                             .toList()
             );
 
-        } else if (targetType == CustomTargetType.USER) {
-            result = userFieldRepository.findByReservationIdAndDeletedAtIsNull(targetId)
-                    .stream()
-                    .map(CustomFieldDto.CustomFieldValueListRes::fromUserEntity)
-                    .toList();
+            return result;
+        }
 
-        } else if (targetType == CustomTargetType.RESOURCE) {
-            result = resourceFieldRepository.findByResourceIdAndDeletedAtIsNull(targetId)
+        // USER 전용 조회
+//        if (targetType == CustomTargetType.USER) {
+//            List<Long> reservationIds = reservationRepository.findIdsByResourceId(targetId);
+//
+//            return userFieldRepository.findByReservationIdInAndDeletedAtIsNull(reservationIds)
+//                    .stream()
+//                    .map(CustomFieldDto.CustomFieldValueListRes::fromUserEntity)
+//                    .toList();
+//        }
+
+        // RESOURCE 전용 조회
+        if (targetType == CustomTargetType.RESOURCE) {
+            return resourceFieldRepository.findByResourceIdAndDeletedAtIsNull(targetId)
                     .stream()
                     .map(CustomFieldDto.CustomFieldValueListRes::fromResourceEntity)
                     .toList();
         }
 
-        return result;
+        throw new IllegalArgumentException("유효하지 않은 targetType입니다.");
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

- #113 

<br />

## 📝 요약(Summary)

커스텀 필드 조회 로직 구현했습니다.

특정 리소스에 대해 3가지 방식으로 조회 가능합니다.

- **해당 리소스의 모든 커스텀 필드 값을 조회** : `GET` http://localhost:8080/api/custom-field/value/{resourceId}

- **해당 리소스의 사용자 입력 필드 값만 전부 조회** : `GET` http://localhost:8080/api/custom-field/value/{resourceId}?targetType=USER

- **해당 리소스의 관리자 입력 필드 값만 전부 조회** : `GET` http://localhost:8080/api/custom-field/value/{resourceId}?targetType=RESOURCE

<br />

## 📸스크린샷

- `resourceId`가 101인 커스텀 필드값 조회 결과

<img width="389" height="309" alt="image" src="https://github.com/user-attachments/assets/cebfc08a-363f-440c-b47f-99d0b013f4eb" />

<br />

## 💬 공유사항

`targetType`이 `RESOURCE`인 커스텀 필드 값 조회는 구현하였습니다. `USER` 커스텀 필드 값은 

- `reservationId`가 존재하는지 확인하는 서비스 코드
- 예약 테이블에서 `resourceId`를 가지는 모든 예약 데이터의 `reservationId`를 반환하는 서비스 코드

가 필요해서 예약 레포지토리로 흐름만 잡고 주석처리했습니다.
서비스 코드가 만들어지면 수정하겠습니다!

<br />