### PR TITLE
[Feat] RESOURCE 커스텀 필드 값 수정 로직 구현

### DIFF
--- a/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldValueController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldValueController.java
@@ -43,12 +43,10 @@ public class CustomFieldValueController {
 
 
     // ---------------- RESOURCE 필드 값 수정 --------------------
-    @Operation(summary = "커스텀 필드 값 수정", description = "커스텀 필드 값을 수정합니다.")
-    @PutMapping("/value/{customFieldValueId}")
-    public void updateCustomFieldValue(
-            @PathVariable Long customFieldId,
-            @RequestBody CustomFieldDto.CustomFieldValue dto
-    ) {
-        // TODO
+    @Operation(summary = "커스텀 필드 값 수정", description = "커스텀 필드 값을 수정합니다. (RESOURCE 전용)")
+    @PutMapping("/value")
+    public BaseResponse updateCustomFieldValues(@RequestBody List<CustomFieldDto.CustomFieldValueUpdateReq> dtoList) {
+        customFieldValueService.update(dtoList);
+        return BaseResponse.success("커스텀 필드 값이 수정되었습니다.");
     }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDto.java
@@ -149,4 +149,20 @@ public class CustomFieldDto {
                     .build();
         }
     }
+
+
+    @Getter
+    @Builder
+    @Schema(description = "RESOURCE 커스텀 필드 값 수정 요청 DTO")
+    public static class CustomFieldValueUpdateReq {
+
+        @Schema(description = "수정할 필드의 ID", example = "1")
+        private Long customFieldId;
+
+        @Schema(description = "수정할 필드 값의 ID", example = "1")
+        private Long customFieldValueId;
+
+        @Schema(description = "수정할 값", example = "회의실 2")
+        private String value;
+    }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceCustomFieldValues.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceCustomFieldValues.java
@@ -19,4 +19,8 @@ public class ResourceCustomFieldValues extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "field_id")
     private CustomFieldDefinitions customFieldDefinition;
+
+    public void updateValue(String newValue) {
+        this.fieldValue = newValue;
+    }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/repository/ResourceCustomFieldValueRepository.java
+++ b/src/main/java/org/example/unibooker/domain/resource/repository/ResourceCustomFieldValueRepository.java
@@ -5,8 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ResourceCustomFieldValueRepository extends JpaRepository<ResourceCustomFieldValues, Long> {
     List<ResourceCustomFieldValues> findByResourceIdAndDeletedAtIsNull(Long resourceId);
+
+    Optional<ResourceCustomFieldValues> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldValueService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldValueService.java
@@ -108,4 +108,36 @@ public class CustomFieldValueService {
 
         throw new IllegalArgumentException("유효하지 않은 targetType입니다.");
     }
+
+
+    // ---------------- RESOURCE 필드 값 수정 --------------------
+    public void update(List<CustomFieldDto.CustomFieldValueUpdateReq> dtoList) {
+
+        for (CustomFieldDto.CustomFieldValueUpdateReq dto : dtoList) {
+
+            // 필드 정의 검증
+            var fieldDef = customFieldRepository.findByIdAndDeletedAtIsNull(dto.getCustomFieldId())
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "존재하지 않거나 삭제된 커스텀 필드입니다. fieldId=" + dto.getCustomFieldId()));
+
+            if (fieldDef.getTargetType() != CustomTargetType.RESOURCE) {
+                throw new IllegalArgumentException(
+                        "RESOURCE 타입의 커스텀 필드만 수정할 수 있습니다. fieldId=" + dto.getCustomFieldId());
+            }
+
+            // 필드 값 엔티티 조회
+            var entity = resourceFieldRepository.findByIdAndDeletedAtIsNull(dto.getCustomFieldValueId())
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "존재하지 않거나 삭제된 커스텀 필드 값입니다. valueId=" + dto.getCustomFieldValueId()));
+
+            // 필드 일치 검증
+            if (!entity.getCustomFieldDefinition().getId().equals(dto.getCustomFieldId())) {
+                throw new IllegalArgumentException(
+                        "customFieldId가 일치하지 않습니다. valueId=" + dto.getCustomFieldValueId());
+            }
+
+            // 값 수정
+            entity.updateValue(dto.getValue());
+        }
+    }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

- #115 

<br />

## 📝 요약(Summary)

커스텀 필드 중 관리자가 입력하는 필드(`targetType`이 `RESOURCE`인 커스텀 필드) 값을 수정하는 로직을 구현했습니다.

사용자 입력 필드는 관리자가 수정하는 것도 이상하고.. 예약/신청 후 수정하는 것도 이상해서
사용자 입력 필드 수정은 그냥 예약/신청 취소 후 다시 예약/신청을 진행하는 걸로 생각했습니다.

<br />

## 📸스크린샷

- 수정 전

   <img width="800" height="160" alt="스크린샷 2025-10-22 024806" src="https://github.com/user-attachments/assets/8d4a49e6-1678-4daf-bd89-e5e52d4cae8c" />

- 수정 후

   <img width="804" height="163" alt="스크린샷 2025-10-22 024820" src="https://github.com/user-attachments/assets/441b24b4-3c2d-4b15-99e7-6991ab665c8c" />

   요청경로 : `PUT` http://localhost:8080/api/custom-field/value
   값이 `회의실 101` -> `회의실 A`로 변경된 걸 확인할 수 있습니다.


## 💬 공유사항

저는 사용자 입력 필드 값 수정이 필요없다고 생각했는데 혹시 다른 의견 있다면 알려주세요!

<br />