### PR TITLE
[Feat] 커스텀 필드 값 삭제 로직 구현

### DIFF
--- a/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldValueController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldValueController.java
@@ -49,4 +49,15 @@ public class CustomFieldValueController {
         customFieldValueService.update(dtoList);
         return BaseResponse.success("커스텀 필드 값이 수정되었습니다.");
     }
+
+
+    // ---------------- 커스텀 필드 값 삭제 --------------------
+    @Operation(summary = "커스텀 필드 값 삭제", description = "커스텀 필드 값을 삭제합니다.")
+    @DeleteMapping("/value")
+    public BaseResponse deleteCustomFieldValues(
+            @RequestBody List<Long> customFieldValueIds
+    ) {
+        customFieldValueService.delete(customFieldValueIds);
+        return BaseResponse.success("커스텀 필드 값이 삭제되었습니다.");
+    }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/repository/UserCustomFieldValueRepository.java
+++ b/src/main/java/org/example/unibooker/domain/resource/repository/UserCustomFieldValueRepository.java
@@ -5,8 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface UserCustomFieldValueRepository extends JpaRepository<UserCustomFieldValues, Long> {
     List<UserCustomFieldValues> findByReservationIdAndDeletedAtIsNull(Long reservationId);
+
+    Optional<UserCustomFieldValues> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldValueService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldValueService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Service
 @RequiredArgsConstructor
@@ -138,6 +139,33 @@ public class CustomFieldValueService {
 
             // 값 수정
             entity.updateValue(dto.getValue());
+        }
+    }
+
+
+    // ---------------- 커스텀 필드 값 삭제 --------------------
+    public void delete(List<Long> valueIds) {
+
+        for (Long valueId : valueIds) {
+
+            AtomicBoolean deleted = new AtomicBoolean(false);
+
+            // RESOURCE 타입 조회
+            resourceFieldRepository.findByIdAndDeletedAtIsNull(valueId).ifPresent(entity -> {
+                entity.softDelete();
+                deleted.set(true);
+            });
+
+            // USER 타입 조회
+            userFieldRepository.findByIdAndDeletedAtIsNull(valueId).ifPresent(entity -> {
+                entity.softDelete();
+                deleted.set(true);
+            });
+
+            if (!deleted.get()) {
+                throw new IllegalArgumentException(
+                        "존재하지 않거나 이미 삭제된 커스텀 필드 값입니다. valueId=" + valueId);
+            }
         }
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

- #117 

<br />

## 📝 요약(Summary)

커스텀 필드 값 삭제 로직 구현했습니다.

예약/신청 취소하면 사용자 입력 필드 값이 삭제된다고 생각해서 여러 개의 값을 한 번에 받아서 삭제 할 수 있도록 구현했습니다.

- 요청경로 : `DELETE` http://localhost:8080/api/custom-field/value
- 요청 데이터 형식
```
// 배열 안에 삭제할 필드 값 아이디를 넣어주면 됩니다.

[1, 2, 3]
```

<br />

## 📸스크린샷 

- 삭제 전

   <img width="816" height="235" alt="스크린샷 2025-10-22 041659" src="https://github.com/user-attachments/assets/3da176aa-009c-4254-94e3-4eae9d9719c1" />

- 삭제 후

   <img width="912" height="206" alt="스크린샷 2025-10-22 041741" src="https://github.com/user-attachments/assets/30e27e05-5159-4f16-a055-fd1d03e06c33" />

<br />