### PR TITLE
[Feat] 커스텀 필드 값 저장 로직 수정

### DIFF
--- a/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldValueController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldValueController.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.example.unibooker.common.BaseResponse;
 import org.example.unibooker.domain.resource.model.CustomFieldDto;
 import org.example.unibooker.domain.resource.model.CustomTargetType;
-import org.example.unibooker.domain.resource.service.CustomFieldService;
 import org.example.unibooker.domain.resource.service.CustomFieldValueService;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,9 +21,10 @@ public class CustomFieldValueController {
 
     // ---------------- 필드 값 생성 --------------------
     @Operation(summary = "커스텀 필드 값 생성", description = "커스텀 필드에 대한 값을 생성합니다. 여러 값도 한 번에 저장 가능")
-    @PostMapping("/values")
-    public BaseResponse registerCustomFieldValues(@RequestBody List<CustomFieldDto.CustomFieldValue> dtos) {
-        customFieldValueService.register(dtos);
+    @PostMapping("/values/{targetId}")
+    public BaseResponse registerCustomFieldValues(@PathVariable Long targetId,
+                                                  @RequestBody List<CustomFieldDto.CustomFieldValue> dtos) {
+        customFieldValueService.register(targetId, dtos);
         return BaseResponse.success("커스텀 필드 값이 생성되었습니다.");
     }
 

--- a/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDto.java
@@ -87,26 +87,23 @@ public class CustomFieldDto {
     @Schema(description = "커스텀 필드 값 생성 DTO")
     public static class CustomFieldValue {
 
-        @Schema(description = "대상 리소스 ID 또는 사용자 ID", example = "101")
-        private Long targetId;
-
         @Schema(description = "필드 ID", example = "1")
         private Long customFieldId;
 
         @Schema(description = "입력 값", example = "회의실 101")
         private String value;
 
-        public UserCustomFieldValues toUserEntity(CustomFieldDefinitions field) {
+        public UserCustomFieldValues toUserEntity(CustomFieldDefinitions field, Long targetId) {
             return UserCustomFieldValues.builder()
-                    .reservationId(this.targetId)
+                    .reservationId(targetId)
                     .fieldValue(this.value)
                     .customFieldDefinition(field)
                     .build();
         }
 
-        public ResourceCustomFieldValues toResourceEntity(CustomFieldDefinitions field) {
+        public ResourceCustomFieldValues toResourceEntity(CustomFieldDefinitions field, Long targetId) {
             return ResourceCustomFieldValues.builder()
-                    .resourceId(this.targetId)
+                    .resourceId(targetId)
                     .fieldValue(this.value)
                     .customFieldDefinition(field)
                     .build();

--- a/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldValueService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldValueService.java
@@ -24,7 +24,7 @@ public class CustomFieldValueService {
 
 
     // -------------------- 커스텀 필드 값 저장 -------------------
-    public void register(List<CustomFieldDto.CustomFieldValue> dtos) {
+    public void register(Long targetId, List<CustomFieldDto.CustomFieldValue> dtos) {
 
         for (CustomFieldDto.CustomFieldValue dto : dtos) {
             CustomFieldDefinitions field = customFieldRepository.findByIdAndDeletedAtIsNull(dto.getCustomFieldId())
@@ -32,10 +32,10 @@ public class CustomFieldValueService {
                             "존재하지 않거나 삭제된 커스텀 필드입니다. fieldId=" + dto.getCustomFieldId()));
 
             if (field.getTargetType() == CustomTargetType.USER) {
-                userFieldRepository.save(dto.toUserEntity(field));
+                userFieldRepository.save(dto.toUserEntity(field, targetId));
 
             } else if (field.getTargetType() == CustomTargetType.RESOURCE) {
-                resourceFieldRepository.save(dto.toResourceEntity(field));
+                resourceFieldRepository.save(dto.toResourceEntity(field, targetId));
 
             } else {
                 throw new IllegalArgumentException("알 수 없는 타겟 타입입니다. fieldId=" + dto.getCustomFieldId());


### PR DESCRIPTION
## 📝 요약(Summary)

저장 요청 DTO랑 요청경로에서 `targetId` 부분 수정했습니다!

기존에는 

```
[
    {
        "targetId": 101,
        "customFieldId": 1,
        "value": "회의실 101"
    },
    {
        "targetId": 101,
        "customFieldId": 2,
        "value": "회의실 예약자 전화번호"
    },
    {
        "targetId": 102,
        "customFieldId": 1,
        "value": "회의실 102"
    }
]
```

이런 식으로 `targetId`를 모든 데이터마다 받았었는데, 생각해보니 targetId가 동일하게 요청이 들어올 것 같아서 경로로 뺐어요!!

요청경로 변경 : `POST` http://localhost:8080/api/custom-field/values -> http://localhost:8080/api/custom-field/values/{targetId}

데이터는 아래처럼 보내주시면 됩니다!

```
[
  {
    "customFieldId": 1,
    "value": "회의실 A"
  },
  {
    "customFieldId": 2,
    "value": "노트북 필요"
  }
]
```

<br />

## 📸스크린샷

위 데이터로 요청했을 때 데이터 잘 들어가는 거 확인했습니다!

- `customFieldId`가 1인 필드는 `targetType`이 `RESOURCE`이고 2는 `USER`입니다!

<img width="872" height="180" alt="image" src="https://github.com/user-attachments/assets/8e048f31-9a66-4e7e-9e75-c1e10fea8fc6" />

<img width="809" height="182" alt="image" src="https://github.com/user-attachments/assets/aa314c48-775e-4a17-b6a7-6a929e8c7b29" />

<br />