### PR TITLE
[Modify] 커스텀 필드 값 조회 로직 수정

### DIFF
--- a/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldValueController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldValueController.java
@@ -29,17 +29,23 @@ public class CustomFieldValueController {
     }
 
 
-    // ---------------- 필드 값 조회 --------------------
+    // ---------------- 리소스 필드 값 조회 --------------------
     @Operation(summary = "특정 리소스의 커스텀 필드 값 조회",
-            description = "특정 리소스에 대한 커스텀 필드 값을 조회합니다. targetType이 없으면 전체 조회합니다.")
-    @GetMapping("/value/{targetId}")
-    public BaseResponse<List<CustomFieldDto.CustomFieldValueListRes>> getCustomFieldValues(
-            @PathVariable Long targetId,
-            @RequestParam(required = false) CustomTargetType targetType // USER / RESOURCE / null
-    ) {
-        List<CustomFieldDto.CustomFieldValueListRes> response = customFieldValueService.getCustomFieldValues(targetId, targetType);
+            description = "특정 리소스에 대한 커스텀 필드 값을 조회합니다.")
+    @GetMapping("/value/resource/{resourceId}")
+    public BaseResponse<List<CustomFieldDto.CustomFieldValueListRes>> getResourceFieldValues(@PathVariable Long resourceId) {
+        List<CustomFieldDto.CustomFieldValueListRes> response = customFieldValueService.getResourceFieldValues(resourceId);
         return BaseResponse.success(response);
     }
+
+
+    // -------------------- 특정 예약의 커스텀 필드 값 조회 -------------------
+//    @Operation(summary = "예약 기반 커스텀 필드 값 조회", description = "예약 ID에 해당하는 커스텀 필드 값을 조회합니다.")
+//    @GetMapping("/value/reservation/{reservationId}")
+//    public BaseResponse<List<CustomFieldDto.CustomFieldValueListRes>> getUserFieldValuesByReservation(@PathVariable Long reservationId) {
+//        List<CustomFieldDto.CustomFieldValueListRes> result = customFieldValueService.getUserFieldValuesByReservation(reservationId);
+//        return BaseResponse.success(result);
+//    }
 
 
     // ---------------- RESOURCE 필드 값 수정 --------------------

--- a/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldValueService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldValueService.java
@@ -44,71 +44,35 @@ public class CustomFieldValueService {
     }
 
 
-    // -------------------- 커스텀 필드 값 조회 -------------------
-    public List<CustomFieldDto.CustomFieldValueListRes> getCustomFieldValues(Long targetId, CustomTargetType targetType) {
+    // -------------------- 리소스의 커스텀 필드 값 조회 --------------------
+    public List<CustomFieldDto.CustomFieldValueListRes> getResourceFieldValues(Long resourceId) {
 
-        // TODO : 예약 ID 존재 여부 검증하는 서비스 코드가 생기면 레포지토리를 서비스로 변경 후 주석 해제
-        // targetId 존재 여부 검증
-//        boolean exists;
-//        if (targetType == null) {
-//            // 전체 조회 시 — 두 테이블 중 하나라도 존재해야 함
-//            exists = resourceRepository.existsById(targetId) || reservationRepository.existsById(targetId);
-//        } else if (targetType == CustomTargetType.RESOURCE) {
-//            exists = resourceRepository.existsById(targetId);
-//        } else if (targetType == CustomTargetType.USER) {
-//            exists = reservationRepository.existsById(targetId);
-//        } else {
-//            throw new IllegalArgumentException("유효하지 않은 targetType입니다.");
-//        }
-//
-//        if (!exists) {
-//            throw new IllegalArgumentException("존재하지 않는 targetId입니다. id=" + targetId);
-//        }
-
-        List<CustomFieldDto.CustomFieldValueListRes> result = new ArrayList<>();
-
-        // targetType이 null일 경우 → USER + RESOURCE 모두 조회
-        if (targetType == null) {
-            // USER 필드값: 해당 리소스에 연결된 예약들의 값
-//            List<Long> reservationIds = reservationRepository.findIdsByResourceId(targetId);
-//            result.addAll(
-//                    userFieldRepository.findByReservationIdInAndDeletedAtIsNull(reservationIds)
-//                            .stream()
-//                            .map(CustomFieldDto.CustomFieldValueListRes::fromUserEntity)
-//                            .toList()
-//            );
-
-            // RESOURCE 필드값
-            result.addAll(
-                    resourceFieldRepository.findByResourceIdAndDeletedAtIsNull(targetId)
-                            .stream()
-                            .map(CustomFieldDto.CustomFieldValueListRes::fromResourceEntity)
-                            .toList()
-            );
-
-            return result;
+        // 존재 여부 검증
+        if (!resourceRepository.existsById(resourceId)) {
+            throw new IllegalArgumentException("존재하지 않는 리소스입니다. id=" + resourceId);
         }
 
-        // USER 전용 조회
-//        if (targetType == CustomTargetType.USER) {
-//            List<Long> reservationIds = reservationRepository.findIdsByResourceId(targetId);
-//
-//            return userFieldRepository.findByReservationIdInAndDeletedAtIsNull(reservationIds)
-//                    .stream()
-//                    .map(CustomFieldDto.CustomFieldValueListRes::fromUserEntity)
-//                    .toList();
-//        }
-
-        // RESOURCE 전용 조회
-        if (targetType == CustomTargetType.RESOURCE) {
-            return resourceFieldRepository.findByResourceIdAndDeletedAtIsNull(targetId)
-                    .stream()
-                    .map(CustomFieldDto.CustomFieldValueListRes::fromResourceEntity)
-                    .toList();
-        }
-
-        throw new IllegalArgumentException("유효하지 않은 targetType입니다.");
+        // RESOURCE 필드 값 조회
+        return resourceFieldRepository.findByResourceIdAndDeletedAtIsNull(resourceId)
+                .stream()
+                .map(CustomFieldDto.CustomFieldValueListRes::fromResourceEntity)
+                .toList();
     }
+
+
+    // -------------------- 예약의 사용자 커스텀 필드 값 조회 --------------------
+//    public List<CustomFieldDto.CustomFieldValueListRes> getUserFieldValuesByReservation(Long reservationId) {
+//
+//        // 예약 존재 여부 검증
+//        var reservation = reservationRepository.findByIdAndDeletedAtIsNull(reservationId)
+//                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 예약입니다. id=" + reservationId));
+//
+//        // USER 필드 값 조회
+//        return userFieldRepository.findByReservationIdAndDeletedAtIsNull(reservation.getId())
+//                .stream()
+//                .map(CustomFieldDto.CustomFieldValueListRes::fromUserEntity)
+//                .toList();
+//    }
 
 
     // ---------------- RESOURCE 필드 값 수정 --------------------


### PR DESCRIPTION
## #️⃣ Issue Number

- #113 

<br />

## 📝 요약(Summary)

커스텀 필드 값 조회 로직에 `targetId`가 `reservationId`가 될 수도 있고 `resourceId`가 될 수도 있는데 그걸 고려하지 않고 코드를 작성해버렸어요..................................ㅋ.ㅋ..ㅋ...ㅋ.ㅋ....ㅋ..ㅋ..............

아래와 같이 수정했습니다!

- `resourceId`로 리소스에 대한 관리자 입력 필드 값(리소스 설명 데이터) 조회 : `GET` http://localhost:8080/api/custom-field/value/resource/{resourceId}
- `reservationId`로 예약에 대한 사용자 입력 필드 값 조회 : `GET` http://localhost:8080/api/custom-field/value/reservation/{reservationId}

<br />

## 📸스크린샷

- `resourceId`가 4인 리소스가 가지는 관리자 입력 필드 값(필드의 `targetType`이 `RESOURCE`인 필드) 목록 조회

   <img width="409" height="306" alt="image" src="https://github.com/user-attachments/assets/402c995f-cbf6-438b-a0a9-29b6df0c2922" />

<br />

## 💬 공유사항

예약 아이디로 사용자 입력 필드 값 조회하는 건 예약 부분이 구현이 안 되어 있어서 아직 못해봤어요.
나중에 구현 되면 서비스 호출로 수정하겠습니다!

<br />