### PR TITLE
[Feat] 리소스 그룹 생성 시 리소스 커스텀 필드 값도 같이 저장

### DIFF
--- a/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDto.java
@@ -125,15 +125,11 @@ public class CustomFieldDto {
         @Schema(description = "값", example = "101호 회의실")
         private String value;
 
-        @Schema(description = "타겟 타입", example = "USER / RESOURCE")
-        private CustomTargetType targetType;
-
         public static CustomFieldValueListRes fromUserEntity(UserCustomFieldValues entity) {
             return CustomFieldValueListRes.builder()
                     .customFieldId(entity.getCustomFieldDefinition().getId())
                     .fieldName(entity.getCustomFieldDefinition().getFieldName())
                     .value(entity.getFieldValue())
-                    .targetType(CustomTargetType.USER)
                     .build();
         }
 
@@ -142,7 +138,6 @@ public class CustomFieldDto {
                     .customFieldId(entity.getCustomFieldDefinition().getId())
                     .fieldName(entity.getCustomFieldDefinition().getFieldName())
                     .value(entity.getFieldValue())
-                    .targetType(CustomTargetType.RESOURCE)
                     .build();
         }
     }

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceDto.java
@@ -53,6 +53,9 @@ public class ResourceDto {
         @Schema(description = "열", example = "4", nullable = true)
         private Integer col;
 
+        @Schema(description = "커스텀 필드 값 목록 (RESOURCE 타입)", nullable = true)
+        private List<CustomFieldDto.CustomFieldValue> customFieldValues;
+
         // 입력값 검증 함수
         public void validate() {
             // 종료일 체크

--- a/src/main/java/org/example/unibooker/domain/resource/service/ResourceService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/ResourceService.java
@@ -3,15 +3,13 @@ package org.example.unibooker.domain.resource.service;
 import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.unibooker.domain.resource.model.ResourceDto;
-import org.example.unibooker.domain.resource.model.ResourceGroups;
-import org.example.unibooker.domain.resource.model.ResourceStatus;
-import org.example.unibooker.domain.resource.model.Resources;
+import org.example.unibooker.domain.resource.model.*;
+import org.example.unibooker.domain.resource.repository.CustomFieldDefinitionRepository;
+import org.example.unibooker.domain.resource.repository.ResourceCustomFieldValueRepository;
 import org.example.unibooker.domain.resource.repository.ResourceGroupRepository;
 import org.example.unibooker.domain.resource.repository.ResourceRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.PathVariable;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -24,6 +22,8 @@ import java.util.stream.Collectors;
 public class ResourceService {
     private final ResourceRepository resourceRepository;
     private final ResourceGroupRepository resourceGroupRepository;
+    private final CustomFieldDefinitionRepository customFieldDefinitionRepository;
+    private final ResourceCustomFieldValueRepository resourceCustomFieldValueRepository;
 
 
     // -------------------- 리소스 등록 --------------------
@@ -36,10 +36,23 @@ public class ResourceService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 리소스 그룹이 존재하지 않습니다."));
 
         Resources resource = dto.toEntity(group);
-
         resource.setTimeInterval(dto.getTimeInterval());
-
         resourceRepository.save(resource);
+
+        // RESOURCE 커스텀 필드 값 저장
+        if (dto.getCustomFieldValues() != null && !dto.getCustomFieldValues().isEmpty()) {
+            for (CustomFieldDto.CustomFieldValue customValueDto : dto.getCustomFieldValues()) {
+                CustomFieldDefinitions field = customFieldDefinitionRepository.findByIdAndDeletedAtIsNull(customValueDto.getCustomFieldId())
+                        .orElseThrow(() -> new IllegalArgumentException(
+                                "존재하지 않거나 삭제된 커스텀 필드입니다. fieldId=" + customValueDto.getCustomFieldId()));
+
+                // RESOURCE 타입만 저장
+                if (field.getTargetType() == CustomTargetType.RESOURCE) {
+                    ResourceCustomFieldValues value = customValueDto.toResourceEntity(field, resource.getId());
+                    resourceCustomFieldValueRepository.save(value);
+                }
+            }
+        }
     }
 
 


### PR DESCRIPTION
## #️⃣ Issue Number

- #18 

<br />

## 📝 요약(Summary)

리소스 등록할 때 관리자 입력한 리소스 입력 필드 값도 같이 저장되도록 구현했습니다.

- 요청경로 : `POST` http://localhost:8080/api/resource

- 요청 데이터 예시
```
{
  "name": "회의실 A",
  "description": "테스트 회의실",
  "resourceGroupId": 6,
  "startDate": "2025-10-20",
  "endDate": "2025-10-30",
  "startTime": "09:00",
  "endTime": "18:00",
  "timeInterval": 60,
  "capacity": 10,
  "row": 4,
  "col": 3,
  "customFieldValues": [
    {
      "customFieldId": 1,
      "value": "빔프로젝터 있음"
    },
    {
      "customFieldId": 2,
      "value": "화이트보드 있음"
    }
  ]
}
```

<br />

## 📸스크린샷

위 입력 데이터가 잘 저장되는 거 확인했습니다!

<img width="940" height="26" alt="image" src="https://github.com/user-attachments/assets/027d0f15-1110-43d6-953e-08b8c98b8d41" />

<br />