### PR TITLE
[Refactor] 탈퇴 계정 재가입 기능 구현 #130

### DIFF
--- a/src/main/java/org/example/unibooker/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/unibooker/domain/user/controller/UserController.java
@@ -109,7 +109,7 @@ public class UserController {
         accessTokenCookie.setHttpOnly(true);
         accessTokenCookie.setSecure(false);
         accessTokenCookie.setPath("/");
-        accessTokenCookie.setMaxAge(0);  // 즉시 만료
+        accessTokenCookie.setMaxAge(0);
 
         response.addCookie(accessTokenCookie);
 
@@ -118,7 +118,7 @@ public class UserController {
         refreshTokenCookie.setHttpOnly(true);
         refreshTokenCookie.setSecure(false);
         refreshTokenCookie.setPath("/");
-        refreshTokenCookie.setMaxAge(0);  // 즉시 만료
+        refreshTokenCookie.setMaxAge(0);
 
         response.addCookie(refreshTokenCookie);
 

--- a/src/main/java/org/example/unibooker/domain/user/model/entity/Users.java
+++ b/src/main/java/org/example/unibooker/domain/user/model/entity/Users.java
@@ -124,6 +124,13 @@ public class Users extends BaseEntity {
     }
 
     /**
+     * 기업 ID 변경
+     */
+    public void updateCompanyId(Long newCompanyId) {
+        this.companyId = newCompanyId;
+    }
+
+    /**
      * 권한 변경
      */
     public void updateRole(UserRole newRole) {

--- a/src/main/java/org/example/unibooker/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/unibooker/domain/user/repository/UserRepository.java
@@ -94,4 +94,29 @@ public interface UserRepository extends JpaRepository<Users, Long> {
      * 권한 목록으로 사용자 페이징 조회
      */
     Page<Users> findByRoleIn(List<UserRole> roles, Pageable pageable);
+
+    /**
+     * DELETED 상태가 아닌 사용자 중 이메일 존재 여부 확인
+     */
+    boolean existsByEmailAndStatusNot(String email, UserStatus status);
+
+    /**
+     * DELETED 상태가 아닌 사용자 중 이메일과 기업 ID, 권한으로 존재 여부 확인
+     */
+    boolean existsByEmailAndCompanyIdAndRoleAndStatusNot(String email, Long companyId, UserRole role, UserStatus status);
+
+    /**
+     * DELETED 상태가 아닌 사용자 중 이메일과 권한 목록으로 존재 여부 확인
+     */
+    boolean existsByEmailAndRoleInAndStatusNot(String email, List<UserRole> roles, UserStatus status);
+
+    /**
+     * 이메일과 상태로 사용자 조회 (재가입 시 탈퇴 계정 찾기용)
+     */
+    Optional<Users> findByEmailAndStatus(String email, UserStatus status);
+
+    /**
+     * 이메일, 기업 ID, 권한, 상태로 사용자 조회 (재가입 시 탈퇴 계정 찾기용)
+     */
+    Optional<Users> findByEmailAndCompanyIdAndRoleAndStatus(String email, Long companyId, UserRole role, UserStatus status);
 }

--- a/src/main/java/org/example/unibooker/domain/user/service/AdminService.java
+++ b/src/main/java/org/example/unibooker/domain/user/service/AdminService.java
@@ -28,6 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -99,29 +100,63 @@ public class AdminService {
 
         /**
          * 관리자 회원가입 처리
-         * - 사업자등록번호, Slug, 이메일 중복 검증
-         * - Company 및 Admin User 생성 (PENDING/INACTIVE 상태)
+         * - 탈퇴 계정 재가입 허용
          */
         @Transactional
         public AdminDto.SignUpResponse signUpAdmin(AdminDto.SignUpRequest request, MultipartFile logoFile) {
+            // 1. 사업자등록번호, Slug 중복 검증
             validateDuplicateBusinessNumber(request.getBusinessNumber());
             validateCompanySlug(request.getCompanySlug());
-            validateDuplicateEmail(request.getEmail());
 
-            Companies company = createCompany(request, logoFile);
-            Companies savedCompany = companyRepository.save(company);
+            // 2. 탈퇴한 ADMIN 계정이 있는지 확인
+            Optional<Users> deletedAdmin = userRepository.findByEmailAndStatus(
+                    request.getEmail(),
+                    UserStatus.DELETED
+            );
 
-            String temporaryPassword = generateTemporaryPassword();
-            String encodedPassword = passwordEncoder.encode(temporaryPassword);
+            Companies company;
+            Users admin;
 
-            Users admin = createAdmin(request, savedCompany, encodedPassword);
+            if (deletedAdmin.isPresent() && deletedAdmin.get().isAdmin()) {
+                // 2-1. 탈퇴 ADMIN 계정 복구
+                admin = deletedAdmin.get();
+                admin.restore(); // DELETED → INACTIVE 변경
+
+                // 2-2. 신규 Company 생성
+                company = createCompany(request, logoFile);
+                company = companyRepository.save(company);
+
+                // 2-3. 임시 비밀번호 생성 및 정보 업데이트
+                String temporaryPassword = generateTemporaryPassword();
+                String encodedPassword = passwordEncoder.encode(temporaryPassword);
+
+                admin.updatePassword(encodedPassword);
+                admin.updateName(request.getName());
+                admin.updatePhone(request.getPhone());
+                admin.updateCompanyId(company.getId()); // 새 Company로 연결
+                admin.deactivate(); // INACTIVE 상태로 설정 (승인 대기)
+
+            } else {
+                // 2-4. DELETED 아닌 상태에서 이메일 중복 확인
+                validateDuplicateEmail(request.getEmail());
+
+                // 2-5. 신규 Company 및 Admin 생성
+                company = createCompany(request, logoFile);
+                company = companyRepository.save(company);
+
+                String temporaryPassword = generateTemporaryPassword();
+                String encodedPassword = passwordEncoder.encode(temporaryPassword);
+
+                admin = createAdmin(request, company, encodedPassword);
+            }
+
             userRepository.save(admin);
 
             return AdminDto.SignUpResponse.builder()
                     .message("관리자 회원가입 신청이 완료되었습니다. 승인까지 최대 " + ESTIMATED_APPROVAL_DAYS + "일이 소요될 수 있습니다.")
                     .email(request.getEmail())
-                    .companyName(savedCompany.getCompanyName())
-                    .companySlug(savedCompany.getCompanySlug())
+                    .companyName(company.getCompanyName())
+                    .companySlug(company.getCompanySlug())
                     .serviceUrl(null)
                     .estimatedDays(ESTIMATED_APPROVAL_DAYS)
                     .build();
@@ -240,10 +275,10 @@ public class AdminService {
         }
 
         /**
-         * 이메일 중복 검증
+         * 이메일 중복 검증 (DELETED 제외)
          */
         private void validateDuplicateEmail(String email) {
-            if (userRepository.findByEmail(email).isPresent()) {
+            if (userRepository.existsByEmailAndStatusNot(email, UserStatus.DELETED)) {
                 throw new BaseException(BaseResponseStatus.DUPLICATE_EMAIL);
             }
         }
@@ -708,10 +743,10 @@ public class AdminService {
         }
 
         /**
-         * 이메일 중복 검증
+         * 이메일 중복 검증 (DELETED 제외)
          */
         private void validateEmailDuplicate(String email) {
-            if (userRepository.existsByEmail(email)) {
+            if (userRepository.existsByEmailAndStatusNot(email, UserStatus.DELETED)) {
                 throw new BaseException(BaseResponseStatus.DUPLICATE_EMAIL);
             }
         }

--- a/src/main/java/org/example/unibooker/domain/user/service/ManagerService.java
+++ b/src/main/java/org/example/unibooker/domain/user/service/ManagerService.java
@@ -258,10 +258,13 @@ public class ManagerService {
     }
 
     /**
-     * MANAGER 이메일 중복 검증 (ADMIN, MANAGER와 중복 방지)
+     * MANAGER 이메일 중복 검증 (DELETED 제외)
      */
     private void validateEmailDuplicate(String email) {
-        if (userRepository.existsByEmailAndRoleIn(email, List.of(UserRole.ADMIN, UserRole.MANAGER))) {
+        if (userRepository.existsByEmailAndRoleInAndStatusNot(
+                email,
+                List.of(UserRole.ADMIN, UserRole.MANAGER),
+                UserStatus.DELETED)) {
             throw new BaseException(BaseResponseStatus.DUPLICATE_EMAIL);
         }
     }

--- a/src/main/java/org/example/unibooker/domain/user/service/UserService.java
+++ b/src/main/java/org/example/unibooker/domain/user/service/UserService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 사용자 비즈니스 로직 처리 서비스
@@ -37,6 +38,7 @@ public class UserService {
 
     /**
      * 일반 사용자 회원가입 (기업별)
+     * - 탈퇴 계정 재가입 허용
      */
     @Transactional
     public UserDto.SignUpResponse signUpUser(UserDto.SignUpRequest request) {
@@ -49,24 +51,41 @@ public class UserService {
             throw new BaseException(BaseResponseStatus.COMPANY_NOT_APPROVED);
         }
 
-        // 3. 해당 기업 내에서 이메일 중복 확인
-        validateDuplicateEmailInCompany(request.getEmail(), request.getCompanyId());
+        // 3. 탈퇴한 계정이 있는지 확인
+        Optional<Users> deletedUser = userRepository.findByEmailAndCompanyIdAndRoleAndStatus(
+                request.getEmail(),
+                request.getCompanyId(),
+                UserRole.USER,
+                UserStatus.DELETED
+        );
 
-        // 4. 비밀번호 암호화
-        String encodedPassword = passwordEncoder.encode(request.getPassword());
+        Users user;
+        if (deletedUser.isPresent()) {
+            // 3-1. 탈퇴 계정이 있으면 복구 및 정보 업데이트
+            user = deletedUser.get();
+            user.restore(); // DELETED → ACTIVE 변경, deletedAt = null
+            user.updatePassword(passwordEncoder.encode(request.getPassword()));
+            user.updateName(request.getName());
+            user.updatePhone(request.getPhone());
+            user.updateBirthDate(request.getBirthDate());
+            user.updateGender(request.getGender());
+        } else {
+            // 3-2. DELETED 아닌 상태에서 중복 확인
+            validateDuplicateEmailInCompany(request.getEmail(), request.getCompanyId());
 
-        // 5. Users 엔티티 생성
-        Users user = Users.builder()
-                .email(request.getEmail())
-                .password(encodedPassword)
-                .name(request.getName())
-                .phone(request.getPhone())
-                .birthDate(request.getBirthDate())
-                .gender(request.getGender())
-                .companyId(request.getCompanyId())  // ← 기업 ID 설정
-                .role(UserRole.USER)
-                .status(UserStatus.ACTIVE)
-                .build();
+            // 3-3. 신규 사용자 생성
+            user = Users.builder()
+                    .email(request.getEmail())
+                    .password(passwordEncoder.encode(request.getPassword()))
+                    .name(request.getName())
+                    .phone(request.getPhone())
+                    .birthDate(request.getBirthDate())
+                    .gender(request.getGender())
+                    .companyId(request.getCompanyId())
+                    .role(UserRole.USER)
+                    .status(UserStatus.ACTIVE)
+                    .build();
+        }
 
         Users savedUser = userRepository.save(user);
 
@@ -74,7 +93,7 @@ public class UserService {
                 .id(savedUser.getId())
                 .name(savedUser.getName())
                 .email(savedUser.getEmail())
-                .companyId(savedUser.getCompanyId())  // ← 추가
+                .companyId(savedUser.getCompanyId())
                 .role(savedUser.getRole())
                 .status(savedUser.getStatus())
                 .createdAt(savedUser.getCreatedAt())
@@ -82,11 +101,11 @@ public class UserService {
     }
 
     /**
-     * 특정 기업 내에서 USER 이메일 중복 확인
-     * - 같은 Company + USER role 조합으로만 중복 체크
+     * 특정 기업 내에서 USER 이메일 중복 확인 (DELETED 제외)
      */
     private void validateDuplicateEmailInCompany(String email, Long companyId) {
-        if (userRepository.existsByEmailAndCompanyIdAndRole(email, companyId, UserRole.USER)) {
+        if (userRepository.existsByEmailAndCompanyIdAndRoleAndStatusNot(
+                email, companyId, UserRole.USER, UserStatus.DELETED)) {
             throw new BaseException(BaseResponseStatus.DUPLICATE_EMAIL_IN_COMPANY);
         }
     }


### PR DESCRIPTION


## #️⃣ Issue Number

- #130 

## 📝 요약(Summary)

- UserRepository에 DELETED 상태 제외 조회 메서드 추가
- Users 엔티티에 updateCompanyId 메서드 추가
- UserService 회원가입 시 탈퇴 계정 복구 로직 추가
- AdminService 관리자 회원가입 시 탈퇴 계정 재가입 허용
- ManagerService 이메일 중복 검증 시 DELETED 상태 제외
- 탈퇴 계정 재가입 시 기존 데이터 복구 및 정보 업데이트

## 📸스크린샷 (선택)

## 💬 공유사항

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->