### PR TITLE
[Fix] 관리자 프로필 조회 및 회원가입 이메일 중복확인 로직 수정

### DIFF
--- a/src/main/java/org/example/unibooker/config/SecurityConfig.java
+++ b/src/main/java/org/example/unibooker/config/SecurityConfig.java
@@ -52,9 +52,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/super/login").permitAll()
 
                         // ===== 로그아웃 =====
-                        .requestMatchers(HttpMethod.POST, "/api/users/logout").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/admins/logout").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/super/logout").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/users/logout").authenticated()  // ← 인증 필요로 변경
+                        .requestMatchers(HttpMethod.POST, "/api/admins/logout").authenticated()  // ← 인증 필요로 변경
+                        .requestMatchers(HttpMethod.POST, "/api/super/logout").authenticated()  // ← 인증 필요로 변경
 
                         // ===== 상태 조회 =====
                         .requestMatchers(HttpMethod.GET, "/api/admins/status").permitAll()
@@ -68,6 +68,14 @@ public class SecurityConfig {
                         // ===== 기업 정보 조회 =====
                         .requestMatchers(HttpMethod.GET, "/api/companies/slug/**").permitAll()
 
+                        // ===== 프로필 관리 (인증 필요) =====
+                        .requestMatchers(HttpMethod.GET, "/api/admins/me").authenticated()
+                        .requestMatchers(HttpMethod.PATCH, "/api/admins/me").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/admins/me").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/users/profile").authenticated()
+                        .requestMatchers(HttpMethod.PATCH, "/api/users/profile").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/users/profile").authenticated()
+
                         // ===== 정적 리소스 =====
                         .requestMatchers("/uploads/**").permitAll()
 
@@ -79,7 +87,7 @@ public class SecurityConfig {
                                 "/webjars/**"
                         ).permitAll()
 
-                        // ===== 슈퍼 관리자 전용 경로 (인증 필요) =====
+                        // ===== 슈퍼 관리자 전용 경로 =====
                         .requestMatchers("/api/companies/pending").hasRole("SUPER")
                         .requestMatchers("/api/companies/{companyId}").hasRole("SUPER")
                         .requestMatchers("/api/companies/{companyId}/approve").hasRole("SUPER")
@@ -87,7 +95,6 @@ public class SecurityConfig {
 
                         // ===== 리소스 관련 경로 =====
                         .requestMatchers("/api/resource-group/**").permitAll()
-
 
                         // ===== 그 외 모든 요청은 인증 필요 =====
                         .anyRequest().authenticated()

--- a/src/main/java/org/example/unibooker/domain/user/controller/AdminController.java
+++ b/src/main/java/org/example/unibooker/domain/user/controller/AdminController.java
@@ -3,16 +3,19 @@ package org.example.unibooker.domain.user.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.unibooker.common.BaseResponse;
 import org.example.unibooker.common.BaseResponseStatus;
 import org.example.unibooker.common.exception.BaseException;
 import org.example.unibooker.domain.user.model.UserRole;
 import org.example.unibooker.domain.user.model.UserStatus;
 import org.example.unibooker.domain.user.model.dto.AdminDto;
+import org.example.unibooker.domain.user.model.dto.AuthDto;
 import org.example.unibooker.domain.user.model.dto.ManagerDto;
 import org.example.unibooker.domain.user.model.dto.UserDto;
 import org.example.unibooker.domain.user.service.AdminService;
@@ -28,6 +31,7 @@ import org.springframework.web.multipart.MultipartFile;
  * - 매니저 관리 (생성, 조회, 삭제) - ADMIN 권한
  * - 관리자 관리 (목록 조회, 상태 변경) - SUPER_ADMIN 권한
  */
+@Slf4j
 @Tag(name = "Admin API", description = "관리자 및 매니저 관리 API")
 @RestController
 @RequestMapping("/api/admins")
@@ -119,31 +123,46 @@ public class AdminController {
 
     /**
      * 비밀번호 재설정 (첫 로그인 시 필수)
-     * - 임시 비밀번호 검증 후 새 비밀번호로 변경
-     * - isFirstLogin 플래그 해제
      */
-    @Operation(summary = "비밀번호 재설정",
-            description = "첫 로그인 시 임시 비밀번호를 새 비밀번호로 변경합니다.")
     @PatchMapping("/password/reset")
     public BaseResponse<AdminDto.PasswordResetResponse> resetPassword(
             @RequestBody @Valid AdminDto.PasswordResetRequest request,
-            @AuthenticationPrincipal Long userId) {
+            @AuthenticationPrincipal AuthDto.AuthAdmin authAdmin) {
 
-        AdminDto.PasswordResetResponse response = adminService.resetPassword(userId, request);
+        if (authAdmin == null) {
+            throw new BaseException(BaseResponseStatus.UNAUTHORIZED);
+        }
+
+        AdminDto.PasswordResetResponse response = adminService.resetPassword(authAdmin.getId(), request);
         return BaseResponse.success(response);
     }
 
     /**
      * 내 프로필 조회
-     * - UserService의 공통 프로필 조회 로직 사용
      */
-    @Operation(summary = "내 프로필 조회",
-            description = "현재 로그인한 관리자의 프로필 정보를 조회합니다.")
     @GetMapping("/me")
     public BaseResponse<UserDto.ProfileResponse> getMyProfile(
-            @AuthenticationPrincipal Long userId) {
+            @AuthenticationPrincipal AuthDto.AuthAdmin authAdmin,
+            HttpServletRequest request) {  // ← 임시 추가
 
-        UserDto.ProfileResponse response = userService.getMyProfile(userId);
+        // ===== 디버깅 로그 =====
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                log.debug("Cookie: {} = {}", cookie.getName(), cookie.getValue());
+            }
+        } else {
+            log.warn("쿠키가 전달되지 않음");
+        }
+
+        log.debug("authAdmin: {}", authAdmin);
+        // =======================
+
+        if (authAdmin == null) {
+            throw new BaseException(BaseResponseStatus.UNAUTHORIZED);
+        }
+
+        UserDto.ProfileResponse response = userService.getMyProfile(authAdmin.getId());
         return BaseResponse.success(response);
     }
 
@@ -156,9 +175,13 @@ public class AdminController {
     @PatchMapping("/me")
     public BaseResponse<UserDto.ProfileResponse> updateMyProfile(
             @RequestBody @Valid UserDto.ProfileUpdateRequest request,
-            @AuthenticationPrincipal Long userId) {
+            @AuthenticationPrincipal AuthDto.AuthAdmin authAdmin) {
 
-        UserDto.ProfileResponse response = userService.updateMyProfile(userId, request);
+        if (authAdmin == null) {
+            throw new BaseException(BaseResponseStatus.UNAUTHORIZED);
+        }
+
+        UserDto.ProfileResponse response = userService.updateMyProfile(authAdmin.getId(), request);
         return BaseResponse.success(response);
     }
 
@@ -171,9 +194,13 @@ public class AdminController {
     @DeleteMapping("/me")
     public BaseResponse<UserDto.WithdrawResponse> withdraw(
             @RequestBody @Valid UserDto.WithdrawRequest request,
-            @AuthenticationPrincipal Long userId) {
+            @AuthenticationPrincipal AuthDto.AuthAdmin authAdmin) {
 
-        UserDto.WithdrawResponse response = userService.withdraw(userId, request);
+        if (authAdmin == null) {
+            throw new BaseException(BaseResponseStatus.UNAUTHORIZED);
+        }
+
+        UserDto.WithdrawResponse response = userService.withdraw(authAdmin.getId(), request);
         return BaseResponse.success(response);
     }
 
@@ -204,9 +231,13 @@ public class AdminController {
     public BaseResponse<ManagerDto.ManagerListResponse> getManagers(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
-            @AuthenticationPrincipal Long userId) {
+            @AuthenticationPrincipal AuthDto.AuthAdmin authAdmin) {
 
-        ManagerDto.ManagerListResponse response = adminService.getManagers(userId, page, size);
+        if (authAdmin == null) {
+            throw new BaseException(BaseResponseStatus.UNAUTHORIZED);
+        }
+
+        ManagerDto.ManagerListResponse response = adminService.getManagers(authAdmin.getId(), page, size);
         return BaseResponse.success(response);
     }
 
@@ -220,9 +251,13 @@ public class AdminController {
     @PostMapping("/managers")
     public BaseResponse<ManagerDto.CreateResponse> createManager(
             @RequestBody @Valid ManagerDto.CreateRequest request,
-            @AuthenticationPrincipal Long userId) {
+            @AuthenticationPrincipal AuthDto.AuthAdmin authAdmin) {
 
-        ManagerDto.CreateResponse response = adminService.createManager(request, userId);
+        if (authAdmin == null) {
+            throw new BaseException(BaseResponseStatus.UNAUTHORIZED);
+        }
+
+        ManagerDto.CreateResponse response = adminService.createManager(request, authAdmin.getId());
         return BaseResponse.success(response);
     }
 
@@ -236,9 +271,13 @@ public class AdminController {
     @DeleteMapping("/managers/{managerId}")
     public BaseResponse<ManagerDto.ManagerDeleteResponse> deleteManager(
             @PathVariable Long managerId,
-            @AuthenticationPrincipal Long userId) {
+            @AuthenticationPrincipal AuthDto.AuthAdmin authAdmin) {
 
-        ManagerDto.ManagerDeleteResponse response = adminService.deleteManager(managerId, userId);
+        if (authAdmin == null) {
+            throw new BaseException(BaseResponseStatus.UNAUTHORIZED);
+        }
+
+        ManagerDto.ManagerDeleteResponse response = adminService.deleteManager(managerId, authAdmin.getId());
         return BaseResponse.success(response);
     }
 

--- a/src/main/java/org/example/unibooker/domain/user/model/dto/UserDto.java
+++ b/src/main/java/org/example/unibooker/domain/user/model/dto/UserDto.java
@@ -279,6 +279,10 @@ public class UserDto {
         @Schema(description = "사업자등록번호 (companies.number)", example = "123-45-67890")
         private String businessNumber;
 
+        @Schema(description = "기업 로고 URL (companies.logo_url)",
+                example = "https://example.com/logos/company-logo.png")
+        private String logoUrl;
+
         @Schema(description = "첫 로그인 여부 (is_first_login)", example = "false")
         private Boolean isFirstLogin;
 

--- a/src/main/java/org/example/unibooker/domain/user/service/AdminService.java
+++ b/src/main/java/org/example/unibooker/domain/user/service/AdminService.java
@@ -164,10 +164,19 @@ public class AdminService {
 
         /**
          * 회원가입 신청 상태 조회
+         * - ADMIN/MANAGER 권한만 조회
          */
         public AdminDto.StatusResponse checkSignUpStatus(String email) {
-            Users user = userRepository.findByEmail(email)
-                    .orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
+            List<Users> users = userRepository.findByEmailAndRoleIn(
+                    email,
+                    List.of(UserRole.ADMIN, UserRole.MANAGER)
+            );
+
+            if (users.isEmpty()) {
+                throw new BaseException(BaseResponseStatus.USER_NOT_FOUND);
+            }
+
+            Users user = users.get(0);
 
             Companies company = companyRepository.findById(user.getCompanyId())
                     .orElseThrow(() -> new BaseException(BaseResponseStatus.COMPANY_NOT_FOUND));
@@ -275,10 +284,13 @@ public class AdminService {
         }
 
         /**
-         * 이메일 중복 검증 (DELETED 제외)
+         * ADMIN/MANAGER 이메일 중복 검증 (DELETED 제외)
          */
         private void validateDuplicateEmail(String email) {
-            if (userRepository.existsByEmailAndStatusNot(email, UserStatus.DELETED)) {
+            if (userRepository.existsByEmailAndRoleInAndStatusNot(
+                    email,
+                    List.of(UserRole.ADMIN, UserRole.MANAGER),
+                    UserStatus.DELETED)) {
                 throw new BaseException(BaseResponseStatus.DUPLICATE_EMAIL);
             }
         }

--- a/src/main/java/org/example/unibooker/domain/user/service/UserService.java
+++ b/src/main/java/org/example/unibooker/domain/user/service/UserService.java
@@ -119,11 +119,14 @@ public class UserService {
 
     /**
      * ADMIN/MANAGER 이메일 중복 확인
-     * - ADMIN 회원가입 시 사용
      * - ADMIN, MANAGER와만 중복 체크 (USER 제외)
+     * - 한 이메일로 USER + ADMIN 계정 각각 생성 가능
      */
     public boolean existsByEmailForAdmin(String email) {
-        return userRepository.existsByEmailAndRoleIn(email, List.of(UserRole.ADMIN, UserRole.MANAGER));
+        return userRepository.existsByEmailAndRoleIn(
+                email,
+                List.of(UserRole.ADMIN, UserRole.MANAGER)
+        );
     }
 
     /**
@@ -258,15 +261,18 @@ public class UserService {
         Users user = userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
 
-        // 2. 기업명 조회 (ADMIN 또는 MANAGER인 경우)
+        // 2. 기업명 및 로고 조회
         String companyName = null;
         String businessNumber = null;
+        String logoUrl = null;  // ← 추가
+
         if (user.getCompanyId() != null) {
             Companies company = companyRepository.findById(user.getCompanyId())
                     .orElse(null);
             if (company != null) {
                 companyName = company.getCompanyName();
                 businessNumber = company.getBusinessNumber();
+                logoUrl = company.getLogoUrl();  // ← 추가
             }
         }
 
@@ -283,6 +289,7 @@ public class UserService {
                 .companyId(user.getCompanyId())
                 .companyName(companyName)
                 .businessNumber(businessNumber)
+                .logoUrl(logoUrl)  // ← 추가
                 .isFirstLogin(user.getIsFirstLogin())
                 .createdAt(user.getCreatedAt())
                 .updatedAt(user.getUpdatedAt())


### PR DESCRIPTION
## #️⃣ Issue Number

- #130 

## 📝 요약(Summary)

- AdminController: @AuthenticationPrincipal 타입 수정 (Long → AuthDto.AuthAdmin)
- UserDto: ProfileResponse에 logoUrl 필드 추가
- UserService: 
  - 프로필 조회 시 회사 로고 URL 포함
  - existsByEmailForAdmin() 수정 (ADMIN/MANAGER만 중복 체크)
- AdminService:
  - validateDuplicateEmail() 수정 (ADMIN/MANAGER만 중복 체크)
  - checkSignUpStatus() 수정 (ADMIN/MANAGER 계정만 조회)
- SecurityConfig: JWT 인증 필터 설정 수정

한 이메일로 여러 권한 계정 생성 가능하도록 중복확인 로직 개선
- USER 계정 존재 시에도 ADMIN 가입 가능
- 회원가입 상태 조회 시 ADMIN/MANAGER만 대상으로 조회

## 📸스크린샷 (선택)

## 💬 공유사항

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->