### PR TITLE
[Feat] 커스텀 필드 값 여러 개 받을 수 있도록 수정

### DIFF
--- a/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldValueController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/CustomFieldValueController.java
@@ -40,12 +40,12 @@ public class CustomFieldValueController {
 
 
     // -------------------- 특정 예약의 커스텀 필드 값 조회 -------------------
-//    @Operation(summary = "예약 기반 커스텀 필드 값 조회", description = "예약 ID에 해당하는 커스텀 필드 값을 조회합니다.")
-//    @GetMapping("/value/reservation/{reservationId}")
-//    public BaseResponse<List<CustomFieldDto.CustomFieldValueListRes>> getUserFieldValuesByReservation(@PathVariable Long reservationId) {
-//        List<CustomFieldDto.CustomFieldValueListRes> result = customFieldValueService.getUserFieldValuesByReservation(reservationId);
-//        return BaseResponse.success(result);
-//    }
+    @Operation(summary = "예약 기반 커스텀 필드 값 조회", description = "예약 ID에 해당하는 커스텀 필드 값을 조회합니다.")
+    @GetMapping("/value/reservation/{reservationId}")
+    public BaseResponse<List<CustomFieldDto.CustomFieldValueListRes>> getUserFieldValuesByReservation(@PathVariable Long reservationId) {
+        List<CustomFieldDto.CustomFieldValueListRes> result = customFieldValueService.getUserFieldValuesByReservation(reservationId);
+        return BaseResponse.success(result);
+    }
 
 
     // ---------------- RESOURCE 필드 값 수정 --------------------

--- a/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDefinitions.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDefinitions.java
@@ -26,6 +26,10 @@ public class CustomFieldDefinitions extends BaseEntity {
     private CustomDataType dataType;
     private Boolean isRequired;
 
+    // 커스텀 필드 선택 항목
+    @OneToMany(mappedBy = "customFieldDefinition", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CustomFieldSelectDefinitions> customFieldSelectDefinitions = new ArrayList<>();
+
     // 서비스 커스텀 필드 값
     @OneToMany(mappedBy = "customFieldDefinition", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ResourceCustomFieldValues> resourceCustomFieldValues = new ArrayList<>();

--- a/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDto.java
@@ -139,14 +139,14 @@ public class CustomFieldDto {
         @Schema(description = "필드 이름", example = "회의실 이름")
         private String fieldName;
 
-        @Schema(description = "값", example = "101호 회의실")
-        private String value;
+        @Schema(description = "값 목록", example = "[\"101호 회의실\"]")
+        private List<String> values;
 
         public static CustomFieldValueListRes fromUserEntity(UserCustomFieldValues entity) {
             return CustomFieldValueListRes.builder()
                     .customFieldId(entity.getCustomFieldDefinition().getId())
                     .fieldName(entity.getCustomFieldDefinition().getFieldName())
-                    .value(entity.getFieldValue())
+                    .values(List.of(entity.getFieldValue()))
                     .build();
         }
 
@@ -154,10 +154,11 @@ public class CustomFieldDto {
             return CustomFieldValueListRes.builder()
                     .customFieldId(entity.getCustomFieldDefinition().getId())
                     .fieldName(entity.getCustomFieldDefinition().getFieldName())
-                    .value(entity.getFieldValue())
+                    .values(List.of(entity.getFieldValue()))
                     .build();
         }
     }
+
 
 
     @Getter

--- a/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDto.java
@@ -3,6 +3,7 @@ package org.example.unibooker.domain.resource.model;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +32,9 @@ public class CustomFieldDto {
 
         @Schema(description = "필수 여부", example = "true")
         private Boolean required;
+
+        @Schema(description = "선택형 옵션 목록 (RADIO/CHECKBOX)", nullable = true)
+        private List<String> options;
 
         public CustomFieldDefinitions toEntity() {
             return CustomFieldDefinitions.builder()
@@ -66,6 +70,10 @@ public class CustomFieldDto {
 
         @Schema(description = "필수 여부", example = "true")
         private Boolean required;
+
+        @Setter
+        @Schema(description = "선택형 옵션 목록 (RADIO/CHECKBOX)", nullable = true)
+        private List<String> options;
 
         public static CustomFieldRes fromEntity(CustomFieldDefinitions entity) {
             return CustomFieldRes.builder()

--- a/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldDto.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Schema(description = "커스텀 필드 관련 DTO 클래스들")
@@ -91,22 +92,30 @@ public class CustomFieldDto {
         private Long customFieldId;
 
         @Schema(description = "입력 값", example = "회의실 101")
-        private String value;
+        private List<String> values;
 
-        public UserCustomFieldValues toUserEntity(CustomFieldDefinitions field, Long targetId) {
-            return UserCustomFieldValues.builder()
-                    .reservationId(targetId)
-                    .fieldValue(this.value)
-                    .customFieldDefinition(field)
-                    .build();
+        public List<UserCustomFieldValues> toUserEntity(CustomFieldDefinitions field, Long reservationId) {
+            List<UserCustomFieldValues> entities = new ArrayList<>();
+            for (String v : values) {
+                entities.add(UserCustomFieldValues.builder()
+                        .reservationId(reservationId)
+                        .fieldValue(v)
+                        .customFieldDefinition(field)
+                        .build());
+            }
+            return entities;
         }
 
-        public ResourceCustomFieldValues toResourceEntity(CustomFieldDefinitions field, Long targetId) {
-            return ResourceCustomFieldValues.builder()
-                    .resourceId(targetId)
-                    .fieldValue(this.value)
-                    .customFieldDefinition(field)
-                    .build();
+        public List<ResourceCustomFieldValues> toResourceEntities(CustomFieldDefinitions field, Long resourceId) {
+            List<ResourceCustomFieldValues> entities = new ArrayList<>();
+            for (String v : values) {
+                entities.add(ResourceCustomFieldValues.builder()
+                        .resourceId(resourceId)
+                        .fieldValue(v)
+                        .customFieldDefinition(field)
+                        .build());
+            }
+            return entities;
         }
     }
 

--- a/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldSelectDefinitions.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/CustomFieldSelectDefinitions.java
@@ -1,0 +1,24 @@
+package org.example.unibooker.domain.resource.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.unibooker.common.BaseEntity;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomFieldSelectDefinitions extends BaseEntity {
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "field_id")
+    private CustomFieldDefinitions customFieldDefinition;
+}

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceCustomFieldValues.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceCustomFieldValues.java
@@ -16,6 +16,7 @@ public class ResourceCustomFieldValues extends BaseEntity {
     private Long resourceId;
     private String fieldValue;
 
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "field_id")
     private CustomFieldDefinitions customFieldDefinition;

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceDto.java
@@ -27,8 +27,8 @@ public class ResourceDto {
         @Schema(description = "서비스가 속한 그룹 ID", example = "1")
         private Long resourceGroupId;
 
-//        @Schema(description = "서비스 이미지 URL 목록", example = "[\"https://example.com/img1.jpg\", \"https://example.com/img2.jpg\"]")
-//        private List<ResourceImages> resourceImageUrls;
+        @Schema(description = "서비스 이미지 URL 목록", example = "[\"https://example.com/img1.jpg\", \"https://example.com/img2.jpg\"]")
+        private List<ResourceImages> resourceImageUrls;
 
         @Schema(description = "시작 날짜", example = "2025.10.16", nullable = true)
         private LocalDate startDate;
@@ -43,7 +43,7 @@ public class ResourceDto {
         private LocalTime endTime;
 
         @Schema(description = "시간 간격", example = "30 또는 60", nullable = true)
-        private TimeIntervalType timeInterval; // private Integer timeInterval;
+        private int timeInterval; // private Integer timeInterval;
 
         @Schema(description = "인원수", example = "4", nullable = true)
         private Integer capacity;
@@ -108,7 +108,7 @@ public class ResourceDto {
                     .endDate(endDate)
                     .startTime(startTime)
                     .endTime(endTime)
-                    .timeInterval(timeInterval)
+                    .timeInterval(TimeIntervalType.fromMinutes(this.timeInterval))
                     .capacity(capacity)
                     .row(row)
                     .col(col)

--- a/src/main/java/org/example/unibooker/domain/resource/model/Resources.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/Resources.java
@@ -105,15 +105,11 @@ public class Resources extends BaseEntity {
     @Column(nullable = false)
     private Long version = 0L;
 
-    /*
-    public void setTimeInterval(int minutes) {
-        this.timeInterval = TimeIntervalType.fromMinutes(minutes).getMinutes();
+
+    public void setTimeInterval(TimeIntervalType timeInterval) {
+        this.timeInterval = timeInterval;
     }
 
-    public TimeIntervalType getTimeIntervalEnum() {
-        return TimeIntervalType.fromMinutes(this.timeInterval);
-    }
-    */
 
     // 서비스 수정 함수
     public void update(ResourceDto.ResourceUpdateReq dto) {

--- a/src/main/java/org/example/unibooker/domain/resource/repository/CustomFieldSelectRepository.java
+++ b/src/main/java/org/example/unibooker/domain/resource/repository/CustomFieldSelectRepository.java
@@ -1,0 +1,13 @@
+package org.example.unibooker.domain.resource.repository;
+
+import org.example.unibooker.domain.resource.model.CustomFieldDefinitions;
+import org.example.unibooker.domain.resource.model.CustomFieldSelectDefinitions;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CustomFieldSelectRepository extends JpaRepository<CustomFieldSelectDefinitions, Long> {
+    List<CustomFieldSelectDefinitions> findByCustomFieldDefinitionAndDeletedAtIsNull(CustomFieldDefinitions field);
+}

--- a/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldService.java
@@ -1,11 +1,9 @@
 package org.example.unibooker.domain.resource.service;
 
 import lombok.RequiredArgsConstructor;
-import org.example.unibooker.domain.resource.model.CustomFieldDefinitions;
-import org.example.unibooker.domain.resource.model.CustomFieldDto;
-import org.example.unibooker.domain.resource.model.CustomTargetType;
-import org.example.unibooker.domain.resource.model.ResourceGroups;
+import org.example.unibooker.domain.resource.model.*;
 import org.example.unibooker.domain.resource.repository.CustomFieldDefinitionRepository;
+import org.example.unibooker.domain.resource.repository.CustomFieldSelectRepository;
 import org.example.unibooker.domain.resource.repository.ResourceGroupRepository;
 import org.example.unibooker.domain.resource.repository.ResourceRepository;
 import org.springframework.stereotype.Service;
@@ -19,6 +17,7 @@ import java.util.List;
 public class CustomFieldService {
     private final CustomFieldDefinitionRepository customFieldRepository;
     private final ResourceGroupRepository resourceGroupRepository;
+    private final CustomFieldSelectRepository customFieldSelectRepository;
 
 
     // -------------------- 커스텀 필드 생성 --------------------
@@ -42,17 +41,33 @@ public class CustomFieldService {
         List<CustomFieldDefinitions> fields;
 
         if (type != null) {
-            // 특정 targetType만 조회
             fields = customFieldRepository.findByResourceGroupAndTargetTypeAndDeletedAtIsNull(group, type);
         } else {
-            // 전체 조회
             fields = customFieldRepository.findByResourceGroupAndDeletedAtIsNull(group);
         }
 
         return fields.stream()
-                .map(CustomFieldDto.CustomFieldRes::fromEntity)
+                .map(field -> {
+                    CustomFieldDto.CustomFieldRes res = CustomFieldDto.CustomFieldRes.fromEntity(field);
+
+                    // RADIO / CHECKBOX일 경우 옵션 조회
+                    if (field.getDataType() == CustomDataType.RADIO
+                            || field.getDataType() == CustomDataType.CHECKBOX) {
+
+                        List<String> options = customFieldSelectRepository
+                                .findByCustomFieldDefinitionAndDeletedAtIsNull(field)
+                                .stream()
+                                .map(CustomFieldSelectDefinitions::getName)
+                                .toList();
+
+                        res.setOptions(options);
+                    }
+
+                    return res;
+                })
                 .toList();
     }
+
 
 
     // -------------------- 커스텀 필드 수정 --------------------

--- a/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldValueService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldValueService.java
@@ -11,7 +11,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.LinkedHashMap;
 
 @Service
 @RequiredArgsConstructor
@@ -57,19 +60,45 @@ public class CustomFieldValueService {
 
 
     // -------------------- 리소스의 커스텀 필드 값 조회 --------------------
+    @Transactional(readOnly = true)
     public List<CustomFieldDto.CustomFieldValueListRes> getResourceFieldValues(Long resourceId) {
 
-        // 존재 여부 검증
+        // 1️⃣ 리소스 존재 여부 검증
         if (!resourceRepository.existsById(resourceId)) {
             throw new IllegalArgumentException("존재하지 않는 리소스입니다. id=" + resourceId);
         }
 
-        // RESOURCE 필드 값 조회
-        return resourceFieldRepository.findByResourceIdAndDeletedAtIsNull(resourceId)
-                .stream()
-                .map(CustomFieldDto.CustomFieldValueListRes::fromResourceEntity)
-                .toList();
+        // 2️⃣ 모든 RESOURCE 커스텀 필드 값 조회
+        List<ResourceCustomFieldValues> fieldValues = resourceFieldRepository
+                .findByResourceIdAndDeletedAtIsNull(resourceId);
+
+        // 3️⃣ customFieldId 기준으로 그룹핑하여 values 리스트 생성
+        Map<Long, List<String>> groupedValues = fieldValues.stream()
+                .collect(Collectors.groupingBy(
+                        fv -> fv.getCustomFieldDefinition().getId(),
+                        LinkedHashMap::new, // 순서 유지
+                        Collectors.mapping(ResourceCustomFieldValues::getFieldValue, Collectors.toList())
+                ));
+
+        // 4️⃣ DTO 생성
+        List<CustomFieldDto.CustomFieldValueListRes> result = new ArrayList<>();
+        for (Map.Entry<Long, List<String>> entry : groupedValues.entrySet()) {
+            CustomFieldDefinitions field = fieldValues.stream()
+                    .filter(fv -> fv.getCustomFieldDefinition().getId().equals(entry.getKey()))
+                    .findFirst()
+                    .get()
+                    .getCustomFieldDefinition();
+
+            result.add(CustomFieldDto.CustomFieldValueListRes.builder()
+                    .customFieldId(field.getId())
+                    .fieldName(field.getFieldName())
+                    .values(entry.getValue())
+                    .build());
+        }
+
+        return result;
     }
+
 
 
     // -------------------- 예약의 사용자 커스텀 필드 값 조회 --------------------

--- a/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldValueService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldValueService.java
@@ -25,7 +25,7 @@ public class CustomFieldValueService {
 
     // -------------------- 커스텀 필드 값 저장 -------------------
     public List<Object> register(Long targetId, List<CustomFieldDto.CustomFieldValue> dtos) {
-        List<Object> savedUserCustomFieldValues = new ArrayList<>();
+        List<Object> savedEntities = new ArrayList<>();
 
         for (CustomFieldDto.CustomFieldValue dto : dtos) {
             CustomFieldDefinitions field = customFieldRepository.findByIdAndDeletedAtIsNull(dto.getCustomFieldId())
@@ -33,18 +33,27 @@ public class CustomFieldValueService {
                             "존재하지 않거나 삭제된 커스텀 필드입니다. fieldId=" + dto.getCustomFieldId()));
 
             if (field.getTargetType() == CustomTargetType.USER) {
-                savedUserCustomFieldValues.add(userFieldRepository.save(dto.toUserEntity(field, targetId)));
+                List<UserCustomFieldValues> entities = dto.toUserEntity(field, targetId); // 여러 엔티티 리스트
+                for (UserCustomFieldValues entity : entities) {
+                    savedEntities.add(userFieldRepository.save(entity)); // 한 개씩 저장하고 리스트에 추가
+                }
 
             } else if (field.getTargetType() == CustomTargetType.RESOURCE) {
-                savedUserCustomFieldValues.add(resourceFieldRepository.save(dto.toResourceEntity(field, targetId)));
-
+                List<ResourceCustomFieldValues> entities = dto.toResourceEntities(field, targetId);
+                for (ResourceCustomFieldValues entity : entities) {
+                    savedEntities.add(resourceFieldRepository.save(entity)); // 한 개씩 저장하고 리스트에 추가
+                }
             } else {
-                throw new IllegalArgumentException("알 수 없는 타겟 타입입니다. fieldId=" + dto.getCustomFieldId());
+                throw new IllegalArgumentException(
+                        "알 수 없는 타겟 타입입니다. fieldId=" + dto.getCustomFieldId()
+                );
             }
         }
 
-        return savedUserCustomFieldValues;
+        return savedEntities;
     }
+
+
 
 
     // -------------------- 리소스의 커스텀 필드 값 조회 --------------------

--- a/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldValueService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/CustomFieldValueService.java
@@ -1,6 +1,7 @@
 package org.example.unibooker.domain.resource.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.unibooker.domain.reservation.repository.ReservationRepository;
 import org.example.unibooker.domain.resource.model.*;
 import org.example.unibooker.domain.resource.repository.CustomFieldDefinitionRepository;
 import org.example.unibooker.domain.resource.repository.ResourceCustomFieldValueRepository;
@@ -24,6 +25,7 @@ public class CustomFieldValueService {
     private final UserCustomFieldValueRepository userFieldRepository;
     private final ResourceCustomFieldValueRepository resourceFieldRepository;
     private final ResourceRepository resourceRepository;
+    private final ReservationRepository reservationRepository;
 
 
     // -------------------- 커스텀 필드 값 저장 -------------------
@@ -63,16 +65,16 @@ public class CustomFieldValueService {
     @Transactional(readOnly = true)
     public List<CustomFieldDto.CustomFieldValueListRes> getResourceFieldValues(Long resourceId) {
 
-        // 1️⃣ 리소스 존재 여부 검증
+        // 리소스 존재 여부 검증
         if (!resourceRepository.existsById(resourceId)) {
             throw new IllegalArgumentException("존재하지 않는 리소스입니다. id=" + resourceId);
         }
 
-        // 2️⃣ 모든 RESOURCE 커스텀 필드 값 조회
+        // 모든 RESOURCE 커스텀 필드 값 조회
         List<ResourceCustomFieldValues> fieldValues = resourceFieldRepository
                 .findByResourceIdAndDeletedAtIsNull(resourceId);
 
-        // 3️⃣ customFieldId 기준으로 그룹핑하여 values 리스트 생성
+        // customFieldId 기준으로 그룹핑하여 values 리스트 생성
         Map<Long, List<String>> groupedValues = fieldValues.stream()
                 .collect(Collectors.groupingBy(
                         fv -> fv.getCustomFieldDefinition().getId(),
@@ -80,7 +82,7 @@ public class CustomFieldValueService {
                         Collectors.mapping(ResourceCustomFieldValues::getFieldValue, Collectors.toList())
                 ));
 
-        // 4️⃣ DTO 생성
+        // DTO 생성
         List<CustomFieldDto.CustomFieldValueListRes> result = new ArrayList<>();
         for (Map.Entry<Long, List<String>> entry : groupedValues.entrySet()) {
             CustomFieldDefinitions field = fieldValues.stream()
@@ -102,18 +104,44 @@ public class CustomFieldValueService {
 
 
     // -------------------- 예약의 사용자 커스텀 필드 값 조회 --------------------
-//    public List<CustomFieldDto.CustomFieldValueListRes> getUserFieldValuesByReservation(Long reservationId) {
-//
-//        // 예약 존재 여부 검증
-//        var reservation = reservationRepository.findByIdAndDeletedAtIsNull(reservationId)
-//                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 예약입니다. id=" + reservationId));
-//
-//        // USER 필드 값 조회
-//        return userFieldRepository.findByReservationIdAndDeletedAtIsNull(reservation.getId())
-//                .stream()
-//                .map(CustomFieldDto.CustomFieldValueListRes::fromUserEntity)
-//                .toList();
-//    }
+    @Transactional(readOnly = true)
+    public List<CustomFieldDto.CustomFieldValueListRes> getUserFieldValuesByReservation(Long reservationId) {
+
+        // 예약 존재 여부 검증
+        var reservation = reservationRepository.findByIdAndDeletedAtIsNull(reservationId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 예약입니다. id=" + reservationId));
+
+        // USER 커스텀 필드 값 조회 (서비스 메서드 호출)
+        List<UserCustomFieldValues> fieldValues = userFieldRepository
+                .findByReservationIdAndDeletedAtIsNull(reservation.getId());
+
+        // customFieldId 기준으로 그룹핑하여 values 리스트 생성
+        Map<Long, List<String>> groupedValues = fieldValues.stream()
+                .collect(Collectors.groupingBy(
+                        fv -> fv.getCustomFieldDefinition().getId(),
+                        LinkedHashMap::new,
+                        Collectors.mapping(UserCustomFieldValues::getFieldValue, Collectors.toList())
+                ));
+
+        // DTO 생성
+        List<CustomFieldDto.CustomFieldValueListRes> result = new ArrayList<>();
+        for (Map.Entry<Long, List<String>> entry : groupedValues.entrySet()) {
+            CustomFieldDefinitions field = fieldValues.stream()
+                    .filter(fv -> fv.getCustomFieldDefinition().getId().equals(entry.getKey()))
+                    .findFirst()
+                    .get()
+                    .getCustomFieldDefinition();
+
+            result.add(CustomFieldDto.CustomFieldValueListRes.builder()
+                    .customFieldId(field.getId())
+                    .fieldName(field.getFieldName())
+                    .values(entry.getValue())
+                    .build());
+        }
+
+        return result;
+    }
+
 
 
     // ---------------- RESOURCE 필드 값 수정 --------------------

--- a/src/main/java/org/example/unibooker/domain/resource/service/ResourceGroupService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/ResourceGroupService.java
@@ -5,11 +5,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.unibooker.domain.company.model.entity.Companies;
 import org.example.unibooker.domain.company.repository.CompanyRepository;
-import org.example.unibooker.domain.resource.model.CustomFieldDefinitions;
-import org.example.unibooker.domain.resource.model.CustomFieldDto;
-import org.example.unibooker.domain.resource.model.ResourceGroupDto;
-import org.example.unibooker.domain.resource.model.ResourceGroups;
+import org.example.unibooker.domain.resource.model.*;
 import org.example.unibooker.domain.resource.repository.CustomFieldDefinitionRepository;
+import org.example.unibooker.domain.resource.repository.CustomFieldSelectRepository;
 import org.example.unibooker.domain.resource.repository.ResourceGroupRepository;
 import org.example.unibooker.domain.user.model.UserRole;
 import org.example.unibooker.domain.user.model.dto.AuthDto;
@@ -31,6 +29,7 @@ public class ResourceGroupService {
     private final UserRepository userRepository;
     private final CompanyRepository companyRepository;
     private final CustomFieldDefinitionRepository customFieldRepository;
+    private final CustomFieldSelectRepository customFieldSelectRepository;
 
 
     // -------------------- 관리자, 매니저 권한을 가졌는지 확인하는 함수 --------------------
@@ -45,33 +44,46 @@ public class ResourceGroupService {
     @Transactional
     public void register(ResourceGroupDto.ResourceGroupRegisterReq dto, Long userId, Long companyId) {
 
-        // 기업 엔티티 조회
+        // 기업 조회
         Companies company = companyRepository.findById(companyId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 기업 ID입니다."));
 
-        // 사용자 엔티티 조회
+        // 사용자 조회
         Users user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 ID입니다."));
 
         checkAdminOrManager(user);
 
-        // 서비스 그룹 생성 후
+        // 서비스 그룹 생성
         ResourceGroups group = dto.toEntity(user, company);
         resourceGroupRepository.save(group);
 
         // 커스텀 필드 생성
         if (dto.getCustomFields() != null && !dto.getCustomFields().isEmpty()) {
-            List<CustomFieldDefinitions> fields = dto.getCustomFields().stream()
-                    .map(fieldDto -> {
-                        CustomFieldDefinitions entity = fieldDto.toEntity();
-                        entity.setResourceGroup(group); // FK 설정
-                        return entity;
-                    })
-                    .toList();
+            for (CustomFieldDto.CustomFieldReq fieldDto : dto.getCustomFields()) {
 
-            customFieldRepository.saveAll(fields);
+                CustomFieldDefinitions fieldEntity = fieldDto.toEntity();
+                fieldEntity.setResourceGroup(group); // FK 설정
+                customFieldRepository.save(fieldEntity);
+
+                // RADIO / CHECKBOX 선택 항목 처리
+                if (fieldEntity.getDataType() == CustomDataType.RADIO
+                        || fieldEntity.getDataType() == CustomDataType.CHECKBOX) {
+
+                    if (fieldDto.getOptions() != null) {
+                        for (String optionName : fieldDto.getOptions()) {
+                            CustomFieldSelectDefinitions optionEntity = CustomFieldSelectDefinitions.builder()
+                                    .name(optionName)
+                                    .customFieldDefinition(fieldEntity)
+                                    .build();
+                            customFieldSelectRepository.save(optionEntity);
+                        }
+                    }
+                }
+            }
         }
     }
+
 
 
     // -------------------- 리소스 그룹 목록 조회 --------------------

--- a/src/main/java/org/example/unibooker/domain/resource/service/ResourceService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/ResourceService.java
@@ -36,20 +36,24 @@ public class ResourceService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 리소스 그룹이 존재하지 않습니다."));
 
         Resources resource = dto.toEntity(group);
-//        resource.setTimeInterval(dto.getTimeInterval());
+        resource.setTimeInterval(TimeIntervalType.fromMinutes(dto.getTimeInterval()));
         resourceRepository.save(resource);
 
         // RESOURCE 커스텀 필드 값 저장
         if (dto.getCustomFieldValues() != null && !dto.getCustomFieldValues().isEmpty()) {
             for (CustomFieldDto.CustomFieldValue customValueDto : dto.getCustomFieldValues()) {
-                CustomFieldDefinitions field = customFieldDefinitionRepository.findByIdAndDeletedAtIsNull(customValueDto.getCustomFieldId())
+                CustomFieldDefinitions field = customFieldDefinitionRepository
+                        .findByIdAndDeletedAtIsNull(customValueDto.getCustomFieldId())
                         .orElseThrow(() -> new IllegalArgumentException(
                                 "존재하지 않거나 삭제된 커스텀 필드입니다. fieldId=" + customValueDto.getCustomFieldId()));
 
                 // RESOURCE 타입만 저장
                 if (field.getTargetType() == CustomTargetType.RESOURCE) {
-                    ResourceCustomFieldValues value = customValueDto.toResourceEntity(field, resource.getId());
-                    resourceCustomFieldValueRepository.save(value);
+                    // 여러 개의 값이 있을 수 있으므로 반복 저장
+                    List<ResourceCustomFieldValues> values = customValueDto.toResourceEntities(field, resource.getId());
+                    for (ResourceCustomFieldValues value : values) {
+                        resourceCustomFieldValueRepository.save(value);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## #️⃣ Issue Number

- #139 

<br />

## 📝 요약(Summary)

### 1. **커스텀 필드 선택항목 추가 기능 구현**

커스텀 필드의 데이터 타입 중 `radio`랑 `checkbox`는 **단일/다중 선택**으로 선택할 수 있는 항목이 추가로 필요합니다.

프론트에서는 아래 이미지와 같이 선택 항목을 추가로 받을 수 있습니다.

<img width="770" height="821" alt="image" src="https://github.com/user-attachments/assets/1c70460c-d5e2-41d0-8dcc-78a544933faa" />

`부서 A`와 `부서 B`는 **부서명**이라는 커스텀 필드의 선택 항목입니다.
이 관계를 정의하기 위해서 `custom_field_select_definitions` 테이블을 추가하였습니다. 이 테이블에 선택항목 필드를 저장합니다.

- 요청경로 : `POST` http://localhost:8080/api/resource-group
```
{
  "userId": 2,
  "name": "회의실 예약 서비스2",
  "description": "회의실 예약 관련 서비스 그룹2",
  "thumbnail": "https://example.com/thumbnail.jpg",
  "category": "RESERVATION",
  "isAlwaysAvailable": true,
  "companyId": 3,
  "customFields": [
    {
        "fieldName": "예약 타입",
        "description": "회의실 예약 방식 선택",
        "dataType": "RADIO",
        "targetType": "USER",
        "required": true,
        "options": ["예약형", "좌석형"]
    },
    {
        "fieldName": "모니터 사용 여부",
        "description": "모니터 사용하세요?",
        "dataType": "BOOLEAN",
        "targetType": "USER",
        "required": true,
        "options": ["예약형", "좌석형"]
    }
  ]
}
```

이런 식으로 선택항목은 `options`에 배열로 넣어주면 됩니다. 데이터 타입이 `radio`나 `checkbox`가 아니면 선택항목을 추가할 수 있는 입력칸이 나타나지 않지만 실수로 값을 넣었다고 해도 값은 저장되지 않습니다.

<img width="734" height="63" alt="image" src="https://github.com/user-attachments/assets/659f3dfb-cf6e-4a10-8138-d1bc204858b7" />


### 2. **시간 간격 데이터 처리**

시간 간격이 **ENUM** 값이라서 프론트에서 숫자로 30 혹은 60을 받아도 ENUM으로 처리 가능하도록 수정하였습니다.

### 3. **커스텀 필드에 대한 선택 항목 리스트로 반환**

커스텀 필드에 대한 선택 항목을 리스트로 받아서 저장했던 것처럼 커스텀 필드 값을 조회할 때도 선택항목을 리스트로 반환합니다.

<img width="462" height="525" alt="image" src="https://github.com/user-attachments/assets/134d0264-afdd-4ea8-9316-c2c8d54e5854" />


<br />