### PR TITLE
[Feat] 72시간 미로그인 계정 자동 삭제 및 이메일 알림 기능 구현 #48

### DIFF
--- a/src/main/java/org/example/unibooker/UnibookerApplication.java
+++ b/src/main/java/org/example/unibooker/UnibookerApplication.java
@@ -3,9 +3,11 @@ package org.example.unibooker;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class UnibookerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/example/unibooker/common/BaseResponseStatus.java
+++ b/src/main/java/org/example/unibooker/common/BaseResponseStatus.java
@@ -30,6 +30,7 @@ public enum BaseResponseStatus {
     CURRENT_PASSWORD_INCORRECT(30011, "현재 비밀번호가 일치하지 않습니다."),
     ROLE_CONFLICT_IN_COMPANY(30012, "같은 기업 내에서 관리자와 매니저 역할을 동시에 가질 수 없습니다."),
     MANAGER_ALREADY_EXISTS(30013, "해당 이메일로 이미 매니저가 등록되어 있습니다."),
+    ADMIN_MANAGER_EMAIL_EXISTS(30014, "해당 이메일은 이미 관리자 또는 매니저로 등록되어 있습니다."),
 
     // ========== 40000: Company 관련 ==========
     COMPANY_NOT_FOUND(40000, "기업 정보를 찾을 수 없습니다."),

--- a/src/main/java/org/example/unibooker/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/example/unibooker/domain/notification/service/NotificationService.java
@@ -1,6 +1,18 @@
 package org.example.unibooker.domain.notification.service;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 알림 서비스
+ * - 미활성 계정 삭제 알림 (추후 구현)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
 public class NotificationService {
+
     /**
      * TODO: 미활성 계정 자동 삭제 알림 발송 (팀원 구현)
      *
@@ -23,7 +35,7 @@ public class NotificationService {
      *    - 총 삭제 개수
      *    - 삭제 일시
      */
-// public void sendInactiveAccountDeletionNotice(List<Users> deletedAccounts) {
-//     // 구현 필요
-// }
+//    public void sendInactiveAccountDeletionNotice(List<Users> deletedAccounts) {
+//        // 추후 구현
+//    }
 }

--- a/src/main/java/org/example/unibooker/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/example/unibooker/domain/notification/service/NotificationService.java
@@ -1,4 +1,29 @@
 package org.example.unibooker.domain.notification.service;
 
 public class NotificationService {
+    /**
+     * TODO: 미활성 계정 자동 삭제 알림 발송 (팀원 구현)
+     *
+     * 요구사항:
+     * - SUPER 관리자들에게 이메일 알림 발송
+     * - 삭제된 계정 목록 포함 (이메일, 역할, 기업명, 생성일)
+     * - 총 삭제 개수 및 삭제 일시 포함
+     *
+     * @param deletedAccounts 삭제된 계정 목록 (List<Users>)
+     *
+     * 참고 코드:
+     * 1. SUPER 관리자 조회:
+     *    userRepository.findByRoleAndStatus(UserRole.SUPER, UserStatus.ACTIVE)
+     *
+     * 2. 이메일 제목: "[UniBooker] 미활성 계정 자동 삭제 알림"
+     *
+     * 3. 이메일 내용 예시:
+     *    - 72시간 이상 첫 로그인 미완료 계정 자동 삭제
+     *    - 삭제된 계정 목록 (이메일, 역할, 기업명, 생성일)
+     *    - 총 삭제 개수
+     *    - 삭제 일시
+     */
+// public void sendInactiveAccountDeletionNotice(List<Users> deletedAccounts) {
+//     // 구현 필요
+// }
 }

--- a/src/main/java/org/example/unibooker/domain/user/model/entity/Users.java
+++ b/src/main/java/org/example/unibooker/domain/user/model/entity/Users.java
@@ -173,6 +173,7 @@ public class Users extends BaseEntity {
     public void restore() {
         this.setDeletedAt(null);
         this.status = UserStatus.ACTIVE;
+        this.isFirstLogin = true;
     }
 
     /**

--- a/src/main/java/org/example/unibooker/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/unibooker/domain/user/repository/UserRepository.java
@@ -166,4 +166,14 @@ public interface UserRepository extends JpaRepository<Users, Long> {
             Boolean isFirstLogin,
             LocalDateTime createdAtBefore
     );
+
+    /**
+     * 기업 ID와 권한으로 사용자 페이징 조회 (DELETED 제외)
+     */
+    Page<Users> findByCompanyIdAndRoleAndStatusNot(
+            Long companyId,
+            UserRole role,
+            UserStatus status,
+            Pageable pageable
+    );
 }

--- a/src/main/java/org/example/unibooker/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/unibooker/domain/user/repository/UserRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -152,4 +153,17 @@ public interface UserRepository extends JpaRepository<Users, Long> {
      * - ADMIN/MANAGER/SUPER 로그인 시 사용
      */
     List<Users> findByEmailAndRoleInAndStatusNot(String email, List<UserRole> roles, UserStatus status);
+
+    /**
+     * 미활성 첫 로그인 계정 조회 (자동 삭제 대상)
+     * - ADMIN/MANAGER 중 isFirstLogin=true
+     * - status=ACTIVE (INACTIVE, SUSPENDED, DELETED 제외)
+     * - 생성일이 특정 시간 이전
+     */
+    List<Users> findByRoleInAndStatusAndIsFirstLoginAndCreatedAtBefore(
+            List<UserRole> roles,
+            UserStatus status,
+            Boolean isFirstLogin,
+            LocalDateTime createdAtBefore
+    );
 }

--- a/src/main/java/org/example/unibooker/domain/user/service/AdminService.java
+++ b/src/main/java/org/example/unibooker/domain/user/service/AdminService.java
@@ -815,17 +815,15 @@ public class AdminService {
          * - 다른 기업의 계정은 체크하지 않음 (멀티테넌트)
          */
         private void validateEmailDuplicate(String email, Long companyId) {
-            // 1. 같은 기업 내 MANAGER 중복 체크 (DELETED 제외)
-            if (userRepository.existsByEmailAndCompanyIdAndRoleAndStatusNot(
-                    email, companyId, UserRole.MANAGER, UserStatus.DELETED)) {
-                throw new BaseException(BaseResponseStatus.MANAGER_ALREADY_EXISTS);
+            // 1. 전체 시스템에서 ADMIN/MANAGER 이메일 중복 체크 (DELETED 제외)
+            if (userRepository.existsByEmailAndRoleInAndStatusNot(
+                    email,
+                    List.of(UserRole.ADMIN, UserRole.MANAGER),
+                    UserStatus.DELETED)) {
+                throw new BaseException(BaseResponseStatus.ADMIN_MANAGER_EMAIL_EXISTS);
             }
 
-            // 2. 같은 기업 내 ADMIN 역할 충돌 체크 (DELETED 제외)
-            if (userRepository.existsByEmailAndCompanyIdAndRoleAndStatusNot(
-                    email, companyId, UserRole.ADMIN, UserStatus.DELETED)) {
-                throw new BaseException(BaseResponseStatus.ROLE_CONFLICT_IN_COMPANY);
-            }
+            // 2. USER 역할과는 공존 가능하므로 별도 체크 불필요
         }
 
         /**

--- a/src/main/java/org/example/unibooker/domain/user/service/AdminService.java
+++ b/src/main/java/org/example/unibooker/domain/user/service/AdminService.java
@@ -674,7 +674,7 @@ public class AdminService {
         }
 
         /**
-         * 관리자가 자신의 기업 소속 매니저 목록 조회
+         * 관리자가 자신의 기업 소속 매니저 목록 조회 (DELETED 제외)
          */
         public ManagerDto.ManagerListResponse getManagers(Long adminUserId, int page, int size) {
             // 1. Admin 권한 검증
@@ -683,10 +683,11 @@ public class AdminService {
             // 2. 페이징 처리
             Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 
-            // 3. 같은 기업의 매니저 조회
-            Page<Users> managerPage = userRepository.findByCompanyIdAndRole(
+            // 3. 같은 기업의 매니저 조회 (DELETED 제외)
+            Page<Users> managerPage = userRepository.findByCompanyIdAndRoleAndStatusNot(
                     admin.getCompanyId(),
                     UserRole.MANAGER,
+                    UserStatus.DELETED,
                     pageable
             );
 

--- a/src/main/java/org/example/unibooker/infrastructure/email/EmailService.java
+++ b/src/main/java/org/example/unibooker/infrastructure/email/EmailService.java
@@ -1,5 +1,7 @@
 package org.example.unibooker.infrastructure.email;
 
+import org.example.unibooker.domain.user.model.UserRole;
+
 /**
  * 이메일 발송 서비스 인터페이스
  */
@@ -44,4 +46,14 @@ public interface EmailService {
      * @param tempPassword 임시 비밀번호
      */
     void sendPasswordResetEmail(String to, String name, String companyName, String tempPassword);
+
+    /**
+     * 계정 삭제 완료 이메일 발송
+     * - 72시간 미로그인으로 인한 자동 삭제 안내
+     *
+     * @param to 수신자 이메일 (당사자)
+     * @param name 사용자 이름
+     * @param role 사용자 역할 (ADMIN/MANAGER)
+     */
+    void sendAccountDeletionNotice(String to, String name, UserRole role);
 }

--- a/src/main/java/org/example/unibooker/infrastructure/email/EmailServiceImpl.java
+++ b/src/main/java/org/example/unibooker/infrastructure/email/EmailServiceImpl.java
@@ -4,6 +4,7 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.unibooker.domain.user.model.UserRole;
 import org.example.unibooker.infrastructure.email.template.EmailTemplateService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailException;
@@ -69,6 +70,14 @@ public class EmailServiceImpl implements EmailService {
     public void sendPasswordResetEmail(String to, String name, String companyName, String tempPassword) {
         String htmlContent = templateService.renderPasswordResetTemplate(name, companyName, tempPassword);
         String subject = "[UniBooker] 임시 비밀번호가 발급되었습니다";
+
+        sendHtmlEmail(to, subject, htmlContent);
+    }
+
+    @Override
+    public void sendAccountDeletionNotice(String to, String name, UserRole role) {
+        String htmlContent = templateService.renderAccountDeletionTemplate(name, role);
+        String subject = "[UniBooker] 계정이 삭제되었습니다";
 
         sendHtmlEmail(to, subject, htmlContent);
     }

--- a/src/main/java/org/example/unibooker/infrastructure/email/template/EmailTemplateService.java
+++ b/src/main/java/org/example/unibooker/infrastructure/email/template/EmailTemplateService.java
@@ -1,5 +1,7 @@
 package org.example.unibooker.infrastructure.email.template;
 
+import org.example.unibooker.domain.user.model.UserRole;
+
 /**
  * 이메일 템플릿 렌더링 서비스 인터페이스
  */
@@ -35,4 +37,13 @@ public interface EmailTemplateService {
      * @return 렌더링된 HTML 문자열
      */
     String renderPasswordResetTemplate(String name, String companyName, String tempPassword);
+
+    /**
+     * 계정 삭제 완료 이메일 템플릿 렌더링
+     *
+     * @param name 사용자 이름
+     * @param role 사용자 역할 (ADMIN/MANAGER)
+     * @return 렌더링된 HTML 문자열
+     */
+    String renderAccountDeletionTemplate(String name, UserRole role);
 }

--- a/src/main/java/org/example/unibooker/infrastructure/email/template/EmailTemplateServiceImpl.java
+++ b/src/main/java/org/example/unibooker/infrastructure/email/template/EmailTemplateServiceImpl.java
@@ -1,6 +1,7 @@
 package org.example.unibooker.infrastructure.email.template;
 
 import lombok.RequiredArgsConstructor;
+import org.example.unibooker.domain.user.model.UserRole;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
@@ -67,5 +68,17 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
         context.setVariables(variables);
 
         return templateEngine.process(templateName, context);
+    }
+
+    @Override
+    public String renderAccountDeletionTemplate(String name, UserRole role) {
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("name", name);
+        variables.put("role", role.name());  // "ADMIN" 또는 "MANAGER"
+
+        String roleKorean = role == UserRole.ADMIN ? "관리자" : "매니저";
+        variables.put("roleKorean", roleKorean);
+
+        return renderTemplate("email/AccountDeletion", variables);
     }
 }

--- a/src/main/java/org/example/unibooker/scheduler/InactiveAccountCleanupScheduler.java
+++ b/src/main/java/org/example/unibooker/scheduler/InactiveAccountCleanupScheduler.java
@@ -1,0 +1,127 @@
+package org.example.unibooker.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.unibooker.domain.user.model.UserRole;
+import org.example.unibooker.domain.user.model.UserStatus;
+import org.example.unibooker.domain.user.model.entity.Users;
+import org.example.unibooker.domain.user.repository.UserRepository;
+import org.example.unibooker.infrastructure.email.EmailService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 미활성 계정 자동 삭제 스케줄러
+ * - ADMIN/MANAGER 중 첫 로그인 미완료 계정 자동 정리 (72시간)
+ * - 하드 삭제 (DB에서 완전 제거)
+ * - 삭제 시 본인에게 이메일 알림
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class InactiveAccountCleanupScheduler {
+
+    private final UserRepository userRepository;
+    private final EmailService emailService;
+
+    @Value("${app.account-cleanup.inactive-minutes:4320}")  // 기본값: 4320분 = 72시간
+    private int inactiveMinutes;
+
+    @Value("${app.account-cleanup.enabled:true}")
+    private boolean enabled;
+
+    /**
+     * 미활성 계정 자동 삭제 실행
+     * - 매일 새벽 2시 실행 (기본값)
+     * - cron 표현식: application.yml에서 설정 가능
+     */
+    @Scheduled(cron = "${app.account-cleanup.cron:0 0 2 * * *}")
+    @Transactional
+    public void cleanupInactiveAccounts() {
+        if (!enabled) {
+            log.debug("[InactiveAccountCleanup] Cleanup is disabled");
+            return;
+        }
+
+        log.info("[InactiveAccountCleanup] Start: {}", LocalDateTime.now());
+        log.info("[InactiveAccountCleanup] Inactive threshold: {} minutes", inactiveMinutes);
+
+        try {
+            // 1. 삭제 대상 조회
+            LocalDateTime cutoffTime = LocalDateTime.now().minusMinutes(inactiveMinutes);
+            log.info("[InactiveAccountCleanup] Cutoff time: {}", cutoffTime);
+
+            List<Users> inactiveAccounts = userRepository
+                    .findByRoleInAndStatusAndIsFirstLoginAndCreatedAtBefore(
+                            List.of(UserRole.ADMIN, UserRole.MANAGER),
+                            UserStatus.ACTIVE,
+                            true,
+                            cutoffTime
+                    );
+
+            if (inactiveAccounts.isEmpty()) {
+                log.info("[InactiveAccountCleanup] No inactive accounts found");
+                return;
+            }
+
+            log.info("[InactiveAccountCleanup] Found {} inactive accounts",
+                    inactiveAccounts.size());
+
+            // 2. 삭제 전 로그 기록 및 본인에게 이메일 발송
+            for (Users account : inactiveAccounts) {
+                log.info("- {} (Role: {}, Company ID: {}, Created: {})",
+                        account.getEmail(),
+                        account.getRole(),
+                        account.getCompanyId(),
+                        account.getCreatedAt());
+
+                // 감사 추적용 상세 로그
+                log.warn("[HARD_DELETE] id={}, email={}, role={}, companyId={}, name={}, createdAt={}",
+                        account.getId(),
+                        account.getEmail(),
+                        account.getRole(),
+                        account.getCompanyId(),
+                        account.getName(),
+                        account.getCreatedAt());
+
+                // 본인에게 삭제 완료 이메일 발송
+                try {
+                    emailService.sendAccountDeletionNotice(
+                            account.getEmail(),
+                            account.getName(),
+                            account.getRole()
+                    );
+                    log.info("[InactiveAccountCleanup] Deletion notice sent to: {}",
+                            account.getEmail());
+                } catch (Exception e) {
+                    log.error("[InactiveAccountCleanup] Failed to send email to {}: {}",
+                            account.getEmail(), e.getMessage());
+                    // 이메일 실패해도 삭제는 진행
+                }
+            }
+
+            // 3. 하드 삭제 (DB에서 완전 제거)
+            userRepository.deleteAll(inactiveAccounts);
+
+            log.info("[InactiveAccountCleanup] Permanently deleted: {} accounts",
+                    inactiveAccounts.size());
+            log.info("[InactiveAccountCleanup] End: {}", LocalDateTime.now());
+
+        } catch (Exception e) {
+            log.error("[InactiveAccountCleanup] Error occurred: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 테스트용 수동 실행 메서드
+     */
+    public void executeManually() {
+        log.info("[InactiveAccountCleanup] Manual execution triggered");
+        cleanupInactiveAccounts();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -109,6 +109,11 @@ app:
     from: noreply@unibooker.com
     login-url: https://unibooker.com/login
 
+  account-cleanup:
+    enabled: true                    # 자동 삭제 기능 활성화 여부
+    inactive-minutes: 4320               # 미활성 기준 시간 (72시간 = 3일)
+    cron: "0 0 2  * * *"             # 매일 새벽 2시 실행
+
 # =================================================================
 # 서버 설정
 # =================================================================

--- a/src/main/resources/templates/email/AccountDeletion.html
+++ b/src/main/resources/templates/email/AccountDeletion.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>계정 삭제 안내</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Segoe UI', 'Malgun Gothic', sans-serif;
+            line-height: 1.6;
+            color: #333;
+            background-color: #f4f4f4;
+            padding: 20px;
+        }
+
+        .email-container {
+            max-width: 600px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 10px;
+            overflow: hidden;
+            box-shadow: 0 2px 20px rgba(0,0,0,0.1);
+        }
+
+        .header {
+            background: linear-gradient(135deg, #dc3545 0%, #c82333 100%);
+            color: white;
+            padding: 40px 30px;
+            text-align: center;
+        }
+
+        .header .logo {
+            font-size: 48px;
+            margin-bottom: 10px;
+        }
+
+        .header h1 {
+            margin: 0;
+            font-size: 28px;
+            font-weight: 600;
+        }
+
+        .content {
+            padding: 40px 30px;
+        }
+
+        .greeting {
+            font-size: 20px;
+            color: #333;
+            margin-bottom: 20px;
+            font-weight: 500;
+        }
+
+        .content p {
+            margin-bottom: 15px;
+            color: #555;
+            line-height: 1.8;
+        }
+
+        .deletion-box {
+            background: linear-gradient(135deg, #ffe5e5 0%, #ffcccc 100%);
+            border-left: 4px solid #dc3545;
+            padding: 25px;
+            margin: 30px 0;
+            border-radius: 8px;
+            text-align: center;
+        }
+
+        .deletion-box .icon {
+            font-size: 48px;
+            margin-bottom: 10px;
+        }
+
+        .deletion-box .title {
+            font-size: 22px;
+            font-weight: bold;
+            color: #721c24;
+            margin-bottom: 10px;
+        }
+
+        .deletion-box .message {
+            font-size: 16px;
+            color: #721c24;
+        }
+
+        .info-box {
+            background: #f8f9fa;
+            padding: 20px;
+            border-radius: 8px;
+            margin: 25px 0;
+        }
+
+        .info-box .label {
+            font-size: 14px;
+            color: #666;
+            margin-bottom: 5px;
+        }
+
+        .info-box .value {
+            font-size: 16px;
+            font-weight: bold;
+            color: #333;
+            margin-bottom: 15px;
+        }
+
+        .help-box {
+            background: #e7f3ff;
+            border-left: 4px solid #0066cc;
+            padding: 20px;
+            margin: 30px 0;
+            border-radius: 8px;
+        }
+
+        .help-box h3 {
+            font-size: 16px;
+            color: #0066cc;
+            margin-bottom: 10px;
+        }
+
+        .help-box p {
+            margin: 0;
+            color: #004080;
+        }
+
+        .footer {
+            background: #f8f9fa;
+            padding: 30px;
+            text-align: center;
+            border-top: 1px solid #dee2e6;
+        }
+
+        .footer .contact p {
+            margin: 5px 0;
+            color: #666;
+            font-size: 14px;
+        }
+
+        .footer .copyright {
+            margin-top: 20px;
+            padding-top: 20px;
+            border-top: 1px solid #dee2e6;
+            color: #999;
+            font-size: 12px;
+        }
+
+        @media only screen and (max-width: 600px) {
+            body {
+                padding: 10px;
+            }
+
+            .content {
+                padding: 30px 20px;
+            }
+
+            .header {
+                padding: 30px 20px;
+            }
+        }
+    </style>
+</head>
+<body>
+<div class="email-container">
+    <div class="header">
+        <div class="logo">🗑️</div>
+        <h1>UniBooker</h1>
+    </div>
+
+    <div class="content">
+        <div class="greeting">
+            안녕하세요, <strong th:text="${name}">홍길동</strong>님
+        </div>
+
+        <div class="deletion-box">
+            <div class="icon">⚠️</div>
+            <div class="title">계정이 삭제되었습니다</div>
+            <div class="message">
+                72시간 이내에 로그인이 없어 귀하의 계정이 자동으로 삭제되었습니다.
+            </div>
+        </div>
+
+        <p>
+            회원가입 시 안내드린 대로, 3일(72시간) 이내에 로그인하지 않으신
+            <strong th:text="${roleKorean}">역할</strong> 계정이 자동으로 삭제되었습니다.
+        </p>
+
+        <div class="info-box">
+            <div class="label">역할</div>
+            <div class="value" th:text="${roleKorean}">관리자</div>
+
+            <div class="label">삭제 일시</div>
+            <div class="value" th:text="${#temporals.format(#temporals.createNow(), 'yyyy-MM-dd HH:mm')}">2025-10-27 14:00</div>
+        </div>
+
+        <div class="help-box">
+            <h3>💡 다시 계정이 필요하신가요?</h3>
+            <p>
+                계정이 필요하시다면 관리자에게 재신청을 요청해주세요.<br>
+                새로운 계정으로 다시 초대해드리겠습니다.
+            </p>
+        </div>
+    </div>
+
+    <div class="footer">
+        <div class="contact">
+            <p><strong>문의사항이 있으신가요?</strong></p>
+            <p>📧 이메일: support@unibooker.com</p>
+            <p>📞 전화: 1234-5678</p>
+        </div>
+
+        <div class="copyright">
+            © 2025 UniBooker. All rights reserved.
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/email/AdminApproval.html
+++ b/src/main/resources/templates/email/AdminApproval.html
@@ -299,6 +299,14 @@
             </p>
         </div>
 
+        <!-- 3일 내 로그인 안내 추가 -->
+        <div class="warning" style="background: #ffe5e5; border-left: 4px solid #dc3545; margin-top: 20px;">
+            <p>
+                <span class="warning-icon">⏰</span>
+                <strong>중요:</strong> 3일(72시간) 이내에 로그인하지 않으면 계정이 자동으로 삭제됩니다.
+            </p>
+        </div>
+
         <!-- 로그인 버튼 -->
         <div class="button-container">
             <a th:href="${loginUrl}" class="button">

--- a/src/main/resources/templates/email/ManagerCreation.html
+++ b/src/main/resources/templates/email/ManagerCreation.html
@@ -263,6 +263,14 @@
             </p>
         </div>
 
+        <!-- 3일 내 로그인 안내 추가 -->
+        <div class="warning" style="background: #ffe5e5; border-left: 4px solid #dc3545; margin-top: 20px;">
+            <p>
+                <span class="warning-icon">⏰</span>
+                <strong>중요:</strong> 3일(72시간) 이내에 로그인하지 않으면 계정이 자동으로 삭제됩니다.
+            </p>
+        </div>
+
         <!-- 로그인 버튼 -->
         <div class="button-container">
             <a th:href="${loginUrl}" class="button">


### PR DESCRIPTION
## #️⃣ Issue Number

- #48 

## 📝 요약(Summary)

72시간 이내 미로그인 ADMIN/MANAGER 계정을 자동으로 삭제하고 이메일로 알림하는 기능을 구현했습니다.

## 📸스크린샷 (선택)

## 💬 공유사항

- 스케줄러는 매일 새벽 2시에 자동 실행됩니다
- application.yml에서 inactive-minutes, cron 설정 변경 가능
- 테스트 시 inactive-minutes를 5분으로 변경하여 확인 가능
- 로그에 [InactiveAccountCleanup], [HARD_DELETE] 키워드로 추적 가능
- 이메일 발송 실패 시에도 삭제는 진행됩니다