### PR TITLE
[Feat] 슈퍼 관리자 기업별 관리자 목록 조회 및 상태 변경 API 구현 #162

### DIFF
--- a/src/main/java/org/example/unibooker/domain/company/controller/CompanyController.java
+++ b/src/main/java/org/example/unibooker/domain/company/controller/CompanyController.java
@@ -13,7 +13,9 @@ import org.example.unibooker.domain.company.model.CompanyStatus;
 import org.example.unibooker.domain.company.model.dto.CompanyDto;
 import org.example.unibooker.domain.company.repository.CompanyRepository;
 import org.example.unibooker.domain.company.service.CompanyService;
+import org.example.unibooker.domain.user.model.dto.SuperDto;
 import org.example.unibooker.domain.user.service.AdminService;
+import org.example.unibooker.domain.user.service.SuperService;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -29,6 +31,7 @@ public class CompanyController {
     private final AdminService adminService;
     private final CompanyRepository companyRepository;
     private final CompanyService companyService;
+    private final SuperService superService;
 
     @Operation(summary = "Company Slug 중복 확인",
             description = "회원가입 시 사용할 Company Slug의 사용 가능 여부를 확인합니다.")
@@ -144,6 +147,20 @@ public class CompanyController {
         CompanyDto.StatusUpdateResponse response =
                 companyService.updateCompanyStatus(companyId, request.getStatus());
 
+        return BaseResponse.success(response);
+    }
+
+    /**
+     * 특정 기업의 관리자 목록 조회
+     */
+    @Operation(summary = "기업 관리자 목록 조회",
+            description = "특정 기업의 관리자(ADMIN, MANAGER) 목록을 조회합니다. (SUPER 권한 필요)")
+    @PreAuthorize("hasRole('SUPER')")
+    @GetMapping("/{companyId}/managers")
+    public BaseResponse<SuperDto.CompanyManagerListResponse> getCompanyManagers(
+            @PathVariable Long companyId) {
+
+        SuperDto.CompanyManagerListResponse response = superService.getCompanyManagers(companyId);
         return BaseResponse.success(response);
     }
 }

--- a/src/main/java/org/example/unibooker/domain/company/model/dto/CompanyDto.java
+++ b/src/main/java/org/example/unibooker/domain/company/model/dto/CompanyDto.java
@@ -72,6 +72,11 @@ public class CompanyDto {
         private String email;
         private String phone;
         private UserStatus userStatus;
+
+        // ===== 플랫폼 이용 현황 =====
+        private Long serviceGroupCount;  // 서비스 그룹 수
+        private Long userCount;           // 고객(일반 사용자) 수
+        private LocalDateTime lastLoginAt; // 최근 로그인 일시
     }
 
     // ========== 승인/거절 Response ==========

--- a/src/main/java/org/example/unibooker/domain/resource/repository/ResourceGroupRepository.java
+++ b/src/main/java/org/example/unibooker/domain/resource/repository/ResourceGroupRepository.java
@@ -4,6 +4,7 @@ import org.example.unibooker.domain.resource.model.ResourceGroups;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -28,4 +29,10 @@ public interface ResourceGroupRepository extends JpaRepository<ResourceGroups, L
     @Modifying
     @Query("UPDATE ResourceGroups rg SET rg.viewCount = rg.viewCount + 1 WHERE rg.id = :groupId")
     void incrementViewCount(Long groupId);
+
+    /**
+     * 특정 기업의 리소스 그룹 수 조회 (삭제되지 않은 것만)
+     */
+    @Query("SELECT COUNT(rg) FROM ResourceGroups rg WHERE rg.company.id = :companyId AND rg.deletedAt IS NULL")
+    Long countByCompanyId(@Param("companyId") Long companyId);
 }

--- a/src/main/java/org/example/unibooker/domain/user/controller/SuperController.java
+++ b/src/main/java/org/example/unibooker/domain/user/controller/SuperController.java
@@ -78,4 +78,22 @@ public class SuperController {
 
         return BaseResponse.success(logoutResponse);
     }
+
+    // ========== 관리자 관리 ==========
+
+    /**
+     * 관리자 상태 변경 (ACTIVE ↔ SUSPENDED)
+     */
+    @Operation(summary = "관리자 상태 변경",
+            description = "관리자(ADMIN, MANAGER)의 상태를 변경합니다. (SUPER 권한 필요)")
+    @PatchMapping("/managers/{userId}/status")
+    public BaseResponse<SuperDto.ManagerStatusUpdateResponse> updateManagerStatus(
+            @PathVariable Long userId,
+            @RequestBody @Valid SuperDto.ManagerStatusUpdateRequest request) {
+
+        SuperDto.ManagerStatusUpdateResponse response =
+                superService.updateManagerStatus(userId, request.getStatus());
+
+        return BaseResponse.success(response);
+    }
 }

--- a/src/main/java/org/example/unibooker/domain/user/model/dto/SuperDto.java
+++ b/src/main/java/org/example/unibooker/domain/user/model/dto/SuperDto.java
@@ -6,6 +6,11 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.unibooker.domain.user.model.UserRole;
+import org.example.unibooker.domain.user.model.UserStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 슈퍼 관리자 DTO
@@ -28,5 +33,85 @@ public class SuperDto {
         @NotBlank(message = "비밀번호는 필수입니다")
         @Schema(description = "비밀번호", required = true)
         private String password;
+    }
+
+    // ========== 관리자 관리 관련 ==========
+
+    /**
+     * 특정 기업의 관리자 목록 조회 응답
+     */
+    @Getter
+    @Builder
+    @Schema(description = "기업 관리자 목록 조회 응답")
+    public static class CompanyManagerListResponse {
+
+        @Schema(description = "관리자 목록")
+        private List<CompanyManagerInfo> managers;
+    }
+
+    /**
+     * 기업 관리자 정보
+     */
+    @Getter
+    @Builder
+    @Schema(description = "기업 관리자 정보")
+    public static class CompanyManagerInfo {
+
+        @Schema(description = "사용자 ID", example = "1")
+        private Long userId;
+
+        @Schema(description = "이름", example = "김철수")
+        private String name;
+
+        @Schema(description = "이메일", example = "admin@example.com")
+        private String email;
+
+        @Schema(description = "연락처", example = "010-1234-5678")
+        private String phone;
+
+        @Schema(description = "역할", example = "ADMIN")
+        private UserRole role;
+
+        @Schema(description = "상태", example = "ACTIVE")
+        private UserStatus status;
+
+        @Schema(description = "생성일시", example = "2025-01-01T10:00:00")
+        private LocalDateTime createdAt;
+
+        @Schema(description = "수정일시", example = "2025-01-15T14:30:00")
+        private LocalDateTime updatedAt;
+    }
+
+    /**
+     * 관리자 상태 변경 요청
+     */
+    @Getter
+    @NoArgsConstructor
+    @Schema(description = "관리자 상태 변경 요청")
+    public static class ManagerStatusUpdateRequest {
+
+        @Schema(description = "변경할 상태 (ACTIVE, SUSPENDED)", example = "ACTIVE")
+        private UserStatus status;
+    }
+
+    /**
+     * 관리자 상태 변경 응답
+     */
+    @Getter
+    @Builder
+    @Schema(description = "관리자 상태 변경 응답")
+    public static class ManagerStatusUpdateResponse {
+
+        @Schema(description = "사용자 ID", example = "1")
+        private Long userId;
+
+        @Schema(description = "변경된 상태", example = "ACTIVE")
+        private UserStatus status;
+
+        @Schema(description = "메시지", example = "상태가 변경되었습니다.")
+        private String message;
+
+        @Schema(description = "수정일시", example = "2025-01-15T14:30:00")
+        private LocalDateTime updatedAt;
     }
 }

--- a/src/main/java/org/example/unibooker/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/unibooker/domain/user/repository/UserRepository.java
@@ -6,6 +6,8 @@ import org.example.unibooker.domain.user.model.entity.Users;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -197,4 +199,16 @@ public interface UserRepository extends JpaRepository<Users, Long> {
      * 기업 ID와 권한으로 사용자 수 조회
      */
     long countByCompanyIdAndRole(Long companyId, UserRole role);
+
+    /**
+     * 특정 기업의 일반 사용자(USER) 수 조회
+     */
+    @Query("SELECT COUNT(u) FROM Users u WHERE u.companyId = :companyId AND u.role = 'USER'")
+    Long countUsersByCompanyId(@Param("companyId") Long companyId);
+
+    /**
+     * 특정 기업의 최근 로그인 일시 조회
+     */
+    @Query("SELECT MAX(u.updatedAt) FROM Users u WHERE u.companyId = :companyId AND u.role = 'USER'")
+    LocalDateTime findLastLoginByCompanyId(@Param("companyId") Long companyId);
 }

--- a/src/main/java/org/example/unibooker/domain/user/service/AdminService.java
+++ b/src/main/java/org/example/unibooker/domain/user/service/AdminService.java
@@ -7,6 +7,7 @@ import org.example.unibooker.domain.company.model.entity.Companies;
 import org.example.unibooker.domain.company.model.dto.CompanyDto;
 import org.example.unibooker.domain.company.model.CompanyStatus;
 import org.example.unibooker.domain.company.repository.CompanyRepository;
+import org.example.unibooker.domain.resource.repository.ResourceGroupRepository;
 import org.example.unibooker.domain.user.model.*;
 import org.example.unibooker.domain.user.model.dto.AdminDto;
 import org.example.unibooker.domain.user.model.dto.ManagerDto;
@@ -47,6 +48,7 @@ public class AdminService {
     private final AuthService authService;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final ResourceGroupRepository resourceGroupRepository;
 
     /**
      * AdminService 생성자 (DI)
@@ -57,10 +59,12 @@ public class AdminService {
                         FileUploadUtil fileUploadUtil,
                         EmailService emailService,
                         AuthService authService,
+                        ResourceGroupRepository resourceGroupRepository,
                         @Value("${app.base-url:http://localhost:5173}") String baseUrl) {
 
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.resourceGroupRepository = resourceGroupRepository;
         this.signUpService = new SignUp(userRepository, companyRepository, passwordEncoder, fileUploadUtil);
 
         // ✅ 수정: authService와 emailService 순서 변경
@@ -68,8 +72,9 @@ public class AdminService {
                 companyRepository,
                 userRepository,
                 passwordEncoder,
-                authService,       // authService가 먼저
-                emailService,      // emailService가 나중
+                authService,
+                emailService,
+                resourceGroupRepository,
                 baseUrl
         );
 
@@ -331,6 +336,7 @@ public class AdminService {
         private final PasswordEncoder passwordEncoder;
         private final EmailService emailService;
         private final AuthService authService;
+        private final ResourceGroupRepository resourceGroupRepository;
         private final String baseUrl;
 
         private static final String CHAR_LOWER = "abcdefghijklmnopqrstuvwxyz";
@@ -345,12 +351,14 @@ public class AdminService {
                         PasswordEncoder passwordEncoder,
                         AuthService authService,
                         EmailService emailService,
+                        ResourceGroupRepository resourceGroupRepository,
                         String baseUrl) {
             this.companyRepository = companyRepository;
             this.userRepository = userRepository;
             this.passwordEncoder = passwordEncoder;
             this.emailService = emailService;
             this.authService = authService;
+            this.resourceGroupRepository = resourceGroupRepository;
             this.baseUrl = baseUrl;
         }
 
@@ -367,15 +375,49 @@ public class AdminService {
 
         /**
          * 기업 상세 정보 조회
+         * - 기업 정보 + 관리자 정보 + 플랫폼 이용 현황
          */
         public CompanyDto.DetailResponse getCompanyDetail(Long companyId) {
+            // 1. 기업 조회
             Companies company = companyRepository.findById(companyId)
                     .orElseThrow(() -> new BaseException(BaseResponseStatus.COMPANY_NOT_FOUND));
 
+            // 2. 관리자 조회
             Users admin = userRepository.findByCompanyIdAndRole(companyId, UserRole.ADMIN)
                     .orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
 
-            return convertToDetailResponse(company, admin);
+            // 3. 플랫폼 이용 현황 데이터 조회
+            Long serviceGroupCount = resourceGroupRepository.countByCompanyId(companyId);
+            Long userCount = userRepository.countUsersByCompanyId(companyId);
+            LocalDateTime lastLoginAt = userRepository.findLastLoginByCompanyId(companyId);
+
+            // 4. DTO 변환 및 반환
+            return CompanyDto.DetailResponse.builder()
+                    // 기업 정보
+                    .companyId(company.getId())
+                    .businessNumber(company.getBusinessNumber())
+                    .companyName(company.getCompanyName())
+                    .companySlug(company.getCompanySlug())
+                    .logoUrl(company.getLogoUrl())
+                    .status(company.getStatus())
+                    .createdAt(company.getCreatedAt())
+                    .approvedAt(company.getApprovedAt())
+                    .approvedBy(company.getApprovedBy())
+                    .rejectionReason(company.getRejectionReason())
+
+                    // 관리자 정보
+                    .adminId(admin.getId())
+                    .adminName(admin.getName())
+                    .email(admin.getEmail())
+                    .phone(admin.getPhone())
+                    .userStatus(admin.getStatus())
+
+                    // 플랫폼 이용 현황
+                    .serviceGroupCount(serviceGroupCount != null ? serviceGroupCount : 0L)
+                    .userCount(userCount != null ? userCount : 0L)
+                    .lastLoginAt(lastLoginAt)
+
+                    .build();
         }
 
         /**
@@ -566,29 +608,6 @@ public class AdminService {
                     .phone(admin != null ? admin.getPhone() : null)
                     .status(company.getStatus())
                     .createdAt(company.getCreatedAt())
-                    .build();
-        }
-
-        /**
-         * Company + User -> DetailResponse DTO 변환
-         */
-        private CompanyDto.DetailResponse convertToDetailResponse(Companies company, Users admin) {
-            return CompanyDto.DetailResponse.builder()
-                    .companyId(company.getId())
-                    .businessNumber(company.getBusinessNumber())
-                    .companyName(company.getCompanyName())
-                    .companySlug(company.getCompanySlug())
-                    .logoUrl(company.getLogoUrl())
-                    .status(company.getStatus())
-                    .createdAt(company.getCreatedAt())
-                    .approvedAt(company.getApprovedAt())
-                    .approvedBy(company.getApprovedBy())
-                    .rejectionReason(company.getRejectionReason())
-                    .adminId(admin.getId())
-                    .adminName(admin.getName())
-                    .email(admin.getEmail())
-                    .phone(admin.getPhone())
-                    .userStatus(admin.getStatus())
                     .build();
         }
     }

--- a/src/main/java/org/example/unibooker/domain/user/service/SuperService.java
+++ b/src/main/java/org/example/unibooker/domain/user/service/SuperService.java
@@ -1,11 +1,20 @@
 package org.example.unibooker.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.unibooker.common.BaseResponseStatus;
+import org.example.unibooker.common.exception.BaseException;
+import org.example.unibooker.domain.company.model.entity.Companies;
+import org.example.unibooker.domain.company.repository.CompanyRepository;
 import org.example.unibooker.domain.user.model.UserRole;
+import org.example.unibooker.domain.user.model.UserStatus;
 import org.example.unibooker.domain.user.model.dto.SuperDto;
 import org.example.unibooker.domain.user.model.dto.UserDto;
+import org.example.unibooker.domain.user.model.entity.Users;
+import org.example.unibooker.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 /**
  * 슈퍼 관리자 서비스
@@ -18,6 +27,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class SuperService {
 
     private final AuthService authService;
+    private final UserRepository userRepository;
+    private final CompanyRepository companyRepository;
 
     /**
      * 슈퍼 관리자 로그인
@@ -29,5 +40,75 @@ public class SuperService {
                 request.getPassword(),
                 UserRole.SUPER
         );
+    }
+
+    // ========== 관리자 관리 ==========
+
+    /**
+     * 특정 기업의 관리자 목록 조회
+     */
+    public SuperDto.CompanyManagerListResponse getCompanyManagers(Long companyId) {
+        // 기업 존재 확인
+        Companies company = companyRepository.findById(companyId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.COMPANY_NOT_FOUND));
+
+        // 해당 기업의 ADMIN, MANAGER 조회
+        List<Users> managers = userRepository.findByCompanyIdAndRoleIn(
+                companyId,
+                List.of(UserRole.ADMIN, UserRole.MANAGER)
+        );
+
+        // DTO 변환
+        List<SuperDto.CompanyManagerInfo> managerInfos = managers.stream()
+                .map(user -> SuperDto.CompanyManagerInfo.builder()
+                        .userId(user.getId())
+                        .name(user.getName())
+                        .email(user.getEmail())
+                        .phone(user.getPhone())
+                        .role(user.getRole())
+                        .status(user.getStatus())
+                        .createdAt(user.getCreatedAt())
+                        .updatedAt(user.getUpdatedAt())
+                        .build())
+                .toList();
+
+        return SuperDto.CompanyManagerListResponse.builder()
+                .managers(managerInfos)
+                .build();
+    }
+
+    /**
+     * 관리자 상태 변경 (ACTIVE ↔ SUSPENDED)
+     */
+    @Transactional
+    public SuperDto.ManagerStatusUpdateResponse updateManagerStatus(Long userId, UserStatus newStatus) {
+        // 사용자 조회
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
+
+        // ADMIN 또는 MANAGER만 상태 변경 가능
+        if (user.getRole() != UserRole.ADMIN && user.getRole() != UserRole.MANAGER) {
+            throw new BaseException(BaseResponseStatus.INVALID_USER_ROLE);
+        }
+
+        // 상태 변경 (ACTIVE ↔ SUSPENDED만 허용)
+        if (newStatus == UserStatus.ACTIVE) {
+            user.activate();
+        } else if (newStatus == UserStatus.SUSPENDED) {
+            user.suspend();
+        } else {
+            throw new BaseException(BaseResponseStatus.INVALID_USER_STATUS);
+        }
+
+        userRepository.save(user);
+
+        String message = newStatus == UserStatus.ACTIVE ? "활성화되었습니다." : "정지되었습니다.";
+
+        return SuperDto.ManagerStatusUpdateResponse.builder()
+                .userId(user.getId())
+                .status(user.getStatus())
+                .message(message)
+                .updatedAt(user.getUpdatedAt())
+                .build();
     }
 }


### PR DESCRIPTION


## #️⃣ Issue Number

- #162 

## 📝 요약(Summary)

주요 기능:
- 특정 기업의 관리자(ADMIN, MANAGER) 목록 조회 API
- 관리자 상태 변경(ACTIVE ↔ SUSPENDED) API
- SuperDto에 관리자 관련 DTO 추가
- SuperService에 관리자 관리 비즈니스 로직 추가
- CompanyController에 GET /api/companies/{companyId}/managers 엔드포인트 추가
- SuperController에 PATCH /api/super/managers/{userId}/status 엔드포인트 추가

파일 수정:
- SuperDto.java: CompanyManagerListResponse, ManagerStatusUpdateRequest 등 추가
- SuperService.java: getCompanyManagers, updateManagerStatus 메서드 추가
- CompanyController.java: 관리자 목록 조회 엔드포인트 추가
- SuperController.java: 관리자 상태 변경 엔드포인트 추가
- UserRepository.java: findByCompanyIdAndRoleIn 메서드 추가
- AdminService.java, CompanyDto.java: 기타 개선

## 📸스크린샷 (선택)

## 💬 공유사항

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->