### PR TITLE
[Feat] 플랫폼 관리자 기업/계정/서비스 그룹 관리 기능 구현

### DIFF
--- a/src/main/java/org/example/unibooker/domain/analytics/service/DashboardService.java
+++ b/src/main/java/org/example/unibooker/domain/analytics/service/DashboardService.java
@@ -45,7 +45,7 @@ public class DashboardService {
         int totalReservations = reservationRepository.countByCompanyId(companyId); // 회사 전체 예약
         int activeServiceGroups = resourceGroups.size(); // 활성화된 그룹 수
         int activeServices = resourceRepository.countActiveResourcesByCompanyId(companyId); // 활성 리소스 총합
-        int userCount = userRepository.findAllByCompanyIdAndRole(companyId, UserRole.USER).size(); // 해당 회사에 소속된 사용자 수
+        int userCount = userRepository.findAllByCompany_IdAndRole(companyId, UserRole.USER).size(); // 해당 회사에 소속된 사용자 수
 
 
         // Summary 데이터 구성

--- a/src/main/java/org/example/unibooker/domain/company/repository/CompanyRepository.java
+++ b/src/main/java/org/example/unibooker/domain/company/repository/CompanyRepository.java
@@ -70,4 +70,16 @@ public interface CompanyRepository extends JpaRepository<Companies, Long> {
             @Param("keyword") String keyword,
             Pageable pageable
     );
+
+    /**
+     * 기업 검색 (PENDING 제외 + 키워드 + 페이징)
+     * - 기업관리 목록용: ACTIVE, SUSPENDED만 조회
+     */
+    @Query("SELECT c FROM Companies c WHERE " +
+            "c.status IN ('ACTIVE', 'SUSPENDED') AND " +
+            "(:keyword IS NULL OR c.companyName LIKE %:keyword% OR c.companySlug LIKE %:keyword%)")
+    Page<Companies> searchCompaniesExcludingPending(
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
 }

--- a/src/main/java/org/example/unibooker/domain/company/service/CompanyService.java
+++ b/src/main/java/org/example/unibooker/domain/company/service/CompanyService.java
@@ -133,6 +133,7 @@ public class CompanyService {
     /**
      * 전체 기업 목록 조회 (페이징 + 필터링)
      * - SUPER 권한 필요
+     * - 기업관리 목록용: PENDING 제외 (ACTIVE, SUSPENDED만)
      */
     @Transactional(readOnly = true)
     public CompanyDto.CompanyListResponse getAllCompanies(
@@ -141,8 +142,16 @@ public class CompanyService {
         Pageable pageable = PageRequest.of(page, size,
                 Sort.by(Sort.Direction.DESC, "createdAt"));
 
-        Page<Companies> companyPage = companyRepository.searchCompanies(
-                status, keyword, pageable);
+        Page<Companies> companyPage;
+
+        // ✅ status가 null이면 ACTIVE, SUSPENDED만 조회 (PENDING 제외)
+        if (status == null) {
+            companyPage = companyRepository.searchCompaniesExcludingPending(
+                    keyword, pageable);
+        } else {
+            companyPage = companyRepository.searchCompanies(
+                    status, keyword, pageable);
+        }
 
         List<CompanyDto.CompanyInfo> companies = companyPage.getContent()
                 .stream()
@@ -194,7 +203,7 @@ public class CompanyService {
             company.suspend();
 
             // 5. 소속 ADMIN/MANAGER 자동 정지
-            List<Users> admins = userRepository.findByCompanyIdAndRoleIn(
+            List<Users> admins = userRepository.findByCompany_IdAndRoleIn(
                     companyId,
                     List.of(UserRole.ADMIN, UserRole.MANAGER)
             );
@@ -217,13 +226,13 @@ public class CompanyService {
      * Companies -> CompanyInfo DTO 변환
      */
     private CompanyDto.CompanyInfo convertToCompanyInfo(Companies company) {
-        Users admin = userRepository.findByCompanyIdAndRole(
+        Users admin = userRepository.findByCompany_IdAndRole(
                 company.getId(), UserRole.ADMIN).orElse(null);
 
-        long managerCount = userRepository.countByCompanyIdAndRole(
+        long managerCount = userRepository.countByCompany_IdAndRole(
                 company.getId(), UserRole.MANAGER);
 
-        long userCount = userRepository.countByCompanyIdAndRole(
+        long userCount = userRepository.countByCompany_IdAndRole(
                 company.getId(), UserRole.USER);
 
         return CompanyDto.CompanyInfo.builder()

--- a/src/main/java/org/example/unibooker/domain/resource/controller/ResourceGroupController.java
+++ b/src/main/java/org/example/unibooker/domain/resource/controller/ResourceGroupController.java
@@ -30,8 +30,12 @@ public class ResourceGroupController {
     // ---------------- 목록 조회(SUPER)----------------
     @Operation(summary = "특정 기업의 서비스 그룹 목록 조회", description = "특정 기업의 서비스 그룹 목록을 조회합니다.")
     @GetMapping("/company/{companyId}")
-    public BaseResponse<ResourceGroupDto.ResourceGroupListRes> getAllResourceGroups(@AuthenticationPrincipal AuthDto.AuthenticatedUser authUser, Long companyId) {
-        ResourceGroupDto.ResourceGroupListRes response = resourceGroupService.getResourceGroupsByCompanyId(authUser.getRole(), companyId);
+    public BaseResponse<ResourceGroupDto.ResourceGroupListRes> getAllResourceGroups(
+            @AuthenticationPrincipal AuthDto.AuthenticatedUser authUser,
+            @PathVariable Long companyId
+    ) {
+        ResourceGroupDto.ResourceGroupListRes response =
+                resourceGroupService.getResourceGroupsByCompanyId(authUser.getRole(), companyId);
         return BaseResponse.success(response);
     }
 
@@ -93,23 +97,25 @@ public class ResourceGroupController {
 
 
     // ---------------- 서비스 그룹 활성화 ----------------
-    @Operation(summary = "서비스 그룹 활성화", description = "비활성화된 서비스 그룹을 활성화합니다.")
-    @GetMapping("/active/{resourceGroupId}")
+    @Operation(summary = "서비스 그룹 활성화", description = "비활성화된 서비스 그룹을 활성화합니다. (플랫폼 관리자 전용)")
+    @PatchMapping("/{resourceGroupId}/activate")
     public BaseResponse activateResourceGroup(
+            @AuthenticationPrincipal AuthDto.AuthenticatedUser authUser,
             @PathVariable Long resourceGroupId) {
 
-        resourceGroupService.activate(resourceGroupId);
+        resourceGroupService.activate(authUser, resourceGroupId);
         return BaseResponse.success("서비스 그룹이 활성화되었습니다.");
     }
 
 
     // ---------------- 서비스 그룹 비활성화 ----------------
-    @Operation(summary = "서비스 그룹 비활성화", description = "활성화된 서비스 그룹을 비활성화합니다.")
-    @GetMapping("/inactive/{resourceGroupId}")
+    @Operation(summary = "서비스 그룹 비활성화", description = "활성화된 서비스 그룹을 비활성화합니다. (플랫폼 관리자 전용)")
+    @PatchMapping("/{resourceGroupId}/deactivate")
     public BaseResponse deactivateResourceGroup(
+            @AuthenticationPrincipal AuthDto.AuthenticatedUser authUser,
             @PathVariable Long resourceGroupId) {
 
-        resourceGroupService.deactivate(resourceGroupId);
+        resourceGroupService.deactivate(authUser, resourceGroupId);
         return BaseResponse.success("서비스 그룹이 비활성화되었습니다.");
     }
 }

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroupDto.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroupDto.java
@@ -1,5 +1,6 @@
 package org.example.unibooker.domain.resource.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,6 +23,9 @@ public class ResourceGroupDto {
         @Schema(description = "서비스 그룹 이름", example = "회의실")
         private String name;
 
+        @Schema(description = "서비스 그룹 코드", example = "SRV001")
+        private String groupCode;  // 서비스 그룹 목록 프론트 구조에 맞춘 추가사항
+
         @Schema(description = "서비스 그룹 설명", example = "회의실 관련 예약/신청 서비스 모음")
         private String description;
 
@@ -40,6 +44,7 @@ public class ResourceGroupDto {
         public ResourceGroups toEntity(Users authUser, Companies company) {
            return ResourceGroups.builder()
                     .name(name)
+                    .groupCode(groupCode)  // 서비스 그룹 목록 프론트 구조에 맞춘 추가사항
                     .description(description)
                     .thumbnail(thumbnail)
                     .category(category)
@@ -60,6 +65,9 @@ public class ResourceGroupDto {
 
         @Schema(description = "서비스 그룹 이름", example = "회의실")
         private String name;
+
+        @Schema(description = "서비스 그룹 코드", example = "SRV001")
+        private String groupCode;  // 서비스 그룹 목록 프론트 구조에 맞춘 추가사항
 
         @Schema(description = "서비스 그룹 설명", example = "회의실 관련 예약/신청 서비스 모음")
         private String description;
@@ -84,6 +92,7 @@ public class ResourceGroupDto {
 
             return ResourceGroupUpdateRes.builder()
                     .name(group.getName())
+                    .groupCode(group.getGroupCode())  // 서비스 그룹 목록 프론트 구조에 맞춘 추가사항
                     .description(group.getDescription())
                     .thumbnail(group.getThumbnail())
                     .category(group.getCategory().name())
@@ -105,14 +114,26 @@ public class ResourceGroupDto {
         @Schema(description = "서비스 그룹 이름", example = "회의실")
         private String name;
 
+        @Schema(description = "서비스 그룹 코드", example = "SRV001")
+        private String groupCode;  // 서비스 그룹 목록 프론트 구조에 맞춘 추가사항
+
         @Schema(description = "서비스 그룹 설명", example = "회의실 관련 예약/신청 서비스 모음")
         private String description;
+
+        @Schema(description = "서비스 카테고리", example = "RESERVATION")
+        private String category;  // 서비스 그룹 목록 프론트 구조에 맞춘 추가사항
 
         @Schema(description = "서비스 그룹 생성일", example = "2025.10.13")
         private LocalDateTime createdAt;
 
+        @Schema(description = "서비스 그룹 수정일", example = "2025.10.15")
+        private LocalDateTime updatedAt;  // 서비스 그룹 목록 프론트 구조에 맞춘 추가사항
+
         @Schema(description = "서비스 그룹 생성자", example = "유현경")
         private String administrator;
+
+        @Schema(description = "서비스 그룹 수정자", example = "김철수")
+        private String updatedByName;  // 서비스 그룹 목록 프론트 구조에 맞춘 추가사항
 
         @Schema(description = "서비스 개수", example = "5")
         private int serviceCount;
@@ -120,8 +141,9 @@ public class ResourceGroupDto {
         @Schema(description = "진행중인 서비스 개수", example = "3")
         private int activeServiceCount;
 
+        @JsonProperty("isActive")
         @Schema(description = "서비스 그룹의 상태", example = "true")
-        private boolean isActive;
+        private Boolean isActive;
 
         @Schema(description = "썸네일 URL", example = "https://example.com/thumbnail.jpg")
         private String thumbnail;
@@ -134,13 +156,17 @@ public class ResourceGroupDto {
             return ResourceGroupDetailRes.builder()
                     .id(entity.getId())
                     .name(entity.getName())
+                    .groupCode(entity.getGroupCode())
                     .description(entity.getDescription())
+                    .category(entity.getCategory() != null ? entity.getCategory().name() : null)
                     .thumbnail(entity.getThumbnail())
                     .createdAt(entity.getCreatedAt())
-                    .administrator(entity.getCreatedBy().getName())
+                    .updatedAt(entity.getUpdatedAt())
+                    .administrator(entity.getCreatedBy() != null ? entity.getCreatedBy().getName() : null)
+                    .updatedByName(entity.getUpdatedBy() != null ? entity.getUpdatedBy().getName() : null)
                     .serviceCount(entity.getResources().size())
                     .activeServiceCount(activeServiceCount)
-                    .isActive(entity.getIsActive())
+                    .isActive(entity.getIsActive() != null ? entity.getIsActive() : false)
                     .build();
         }
     }
@@ -163,6 +189,9 @@ public class ResourceGroupDto {
 
         @Schema(description = "리소스 그룹 이름", example = "동아리")
         private String name;
+
+        @Schema(description = "리소스 그룹 코드", example = "SRV001")
+        private String groupCode;  // 서비스 그룹 목록 프론트 구조에 맞춘 추가사항
 
         @Schema(description = "리소스 그룹 설명", example = "동아리 관련 예약/신청 모음")
         private String description;

--- a/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroups.java
+++ b/src/main/java/org/example/unibooker/domain/resource/model/ResourceGroups.java
@@ -19,12 +19,17 @@ import java.util.List;
 @AllArgsConstructor
 public class ResourceGroups extends BaseEntity {
     private String name;
+    private String groupCode;  // 서비스 그룹 목록 프론트 구조에 맞춘 추가사항
     private String description;
     private String thumbnail;
     @Enumerated(EnumType.STRING)
     @Column(length = 20, nullable = false)
     private ServiceCategory category;
+
+    @Column(name = "is_always_available")
     private Boolean isAlwaysAvailable; // 상시모집 여부
+
+    @Column(name = "is_active")
     private Boolean isActive; // 활성화 여부
 
     // 낙관적 락 버전 관리 필드
@@ -61,8 +66,9 @@ public class ResourceGroups extends BaseEntity {
 
 
     // 서비스 그룹 수정 함수
-    public void update(String name, String description, String thumbnail, String category, Boolean isAlwaysAvailable, Users updatedBy) {
+    public void update(String name, String groupCode, String description, String thumbnail, String category, Boolean isAlwaysAvailable, Users updatedBy) {
         if (name != null) this.name = name;
+        if (groupCode != null) this.groupCode = groupCode;  // 서비스 그룹 목록 프론트 구조에 맞춘 추가사항
         if (description != null) this.description = description;
         if (thumbnail != null) this.thumbnail = thumbnail;
         if (category != null) this.category = ServiceCategory.valueOf(category);

--- a/src/main/java/org/example/unibooker/domain/resource/service/ResourceGroupService.java
+++ b/src/main/java/org/example/unibooker/domain/resource/service/ResourceGroupService.java
@@ -157,6 +157,7 @@ public class ResourceGroupService {
 
         resourceGroup.update(
                 dto.getName(),
+                dto.getGroupCode(),  // 서비스 그룹 목록 프론트 구조에 맞춘 추가사항
                 dto.getDescription(),
                 dto.getThumbnail(),
                 dto.getCategory(),
@@ -202,23 +203,30 @@ public class ResourceGroupService {
 
     // -------------------- 리소스 그룹 활성화  --------------------
     @Transactional
-    public void activate(Long resourceGroupId) {
+    public void activate(AuthDto.AuthenticatedUser authUser, Long resourceGroupId) {
 
         try {
-            // TODO : 플랫폼 관리자 권한을 가졌는지 확인
+            // 플랫폼 관리자 권한 확인
+            if (authUser.getRole() != UserRole.SUPER) {
+                throw new IllegalArgumentException("플랫폼 관리자만 서비스 그룹 상태를 변경할 수 있습니다.");
+            }
 
             ResourceGroups resourceGroup = resourceGroupRepository.findByIdAndDeletedAtIsNull(resourceGroupId)
                     .orElseThrow(() -> new IllegalArgumentException("해당 리소스 그룹이 존재하지 않습니다."));
 
             if (Boolean.TRUE.equals(resourceGroup.getIsActive())) {
                 log.info("이미 활성화된 서비스 그룹입니다. id={}", resourceGroupId);
-                return;
+                throw new IllegalArgumentException("이미 활성화된 서비스 그룹입니다.");
             }
 
-            resourceGroup.setIsActive(true);
-            // resourceGroup.setUpdatedBy(user); // 수정자 추후 추가
+            // 수정자 조회
+            Users user = userRepository.findById(authUser.getId())
+                    .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다."));
 
-            log.info("서비스 그룹 활성화 완료 - id={}", resourceGroupId);
+            resourceGroup.setIsActive(true);
+            resourceGroup.setUpdatedBy(user);
+
+            log.info("서비스 그룹 활성화 완료 - id={}, updatedBy={}", resourceGroupId, user.getName());
         } catch (OptimisticLockException e) {
             throw new IllegalStateException("다른 사용자가 동시에 수정 중입니다. 다시 시도해주세요.");
         }
@@ -227,21 +235,29 @@ public class ResourceGroupService {
 
     // -------------------- 리소스 그룹 비활성화  --------------------
     @Transactional
-    public void deactivate(Long resourceGroupId) {
+    public void deactivate(AuthDto.AuthenticatedUser authUser, Long resourceGroupId) {
         try {
+            // 플랫폼 관리자 권한 확인
+            if (authUser.getRole() != UserRole.SUPER) {
+                throw new IllegalArgumentException("플랫폼 관리자만 서비스 그룹 상태를 변경할 수 있습니다.");
+            }
+
             ResourceGroups resourceGroup = resourceGroupRepository.findByIdAndDeletedAtIsNull(resourceGroupId)
                     .orElseThrow(() -> new IllegalArgumentException("해당 리소스 그룹이 존재하지 않습니다."));
 
-
             if (Boolean.FALSE.equals(resourceGroup.getIsActive())) {
                 log.info("이미 비활성화된 서비스 그룹입니다. id={}", resourceGroupId);
-                return;
+                throw new IllegalArgumentException("이미 비활성화된 서비스 그룹입니다.");
             }
 
-            resourceGroup.setIsActive(false);
-            // resourceGroup.setUpdatedBy(user); // 수정자 추후 추가
+            // 수정자 조회
+            Users user = userRepository.findById(authUser.getId())
+                    .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다."));
 
-            log.info("서비스 그룹 비활성화 완료 - id={}", resourceGroupId);
+            resourceGroup.setIsActive(false);
+            resourceGroup.setUpdatedBy(user);
+
+            log.info("서비스 그룹 비활성화 완료 - id={}, updatedBy={}", resourceGroupId, user.getName());
         } catch (OptimisticLockException e) {
             throw new IllegalStateException("다른 사용자가 동시에 수정 중입니다. 다시 시도해주세요.");
         }

--- a/src/main/java/org/example/unibooker/domain/user/model/entity/Users.java
+++ b/src/main/java/org/example/unibooker/domain/user/model/entity/Users.java
@@ -14,11 +14,17 @@ import org.hibernate.annotations.Comment;
  * - 일반 사용자, 관리자, 매니저, 슈퍼관리자 모두 포함
  */
 @Entity
-@Table(name = "users")
-@Builder
+@Table(
+        name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_email_company",
+                        columnNames = {"email", "company_id"}
+                )
+        }
+)
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Comment("사용자")
 public class Users extends BaseEntity {
 
@@ -57,8 +63,9 @@ public class Users extends BaseEntity {
     @Comment("상태")
     private UserStatus status;
 
-    @Comment("기업 ID")
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id")
+    @Comment("기업")
     private Companies company;
 
     @Column(nullable = false)
@@ -242,5 +249,61 @@ public class Users extends BaseEntity {
      */
     public boolean hasManagerAuthority() {
         return this.role == UserRole.MANAGER || hasAdminAuthority();
+    }
+
+    // ========== Builder 패턴 (정적 팩토리) ==========
+
+    /**
+     * Users 엔티티 생성자
+     */
+    @Builder
+    public Users(Long id, String email, String password, String name, String phone,
+                 String birthDate, Gender gender, UserRole role, UserStatus status,
+                 Companies company, Boolean isFirstLogin) {
+        super.setId(id);
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.phone = phone;
+        this.birthDate = birthDate;
+        this.gender = gender;
+        this.role = role != null ? role : UserRole.USER;
+        this.status = status != null ? status : UserStatus.ACTIVE;
+        this.company = company; // SUPER는 null, 나머지는 반드시 설정
+        this.isFirstLogin = isFirstLogin != null ? isFirstLogin : false;
+    }
+
+    /**
+     * SUPER 사용자 생성 (company = null)
+     */
+    public static Users createSuper(String email, String password, String name) {
+        return Users.builder()
+                .email(email)
+                .password(password)
+                .name(name)
+                .role(UserRole.SUPER)
+                .status(UserStatus.ACTIVE)
+                .company(null)
+                .isFirstLogin(false)
+                .build();
+    }
+
+    /**
+     * 기업 소속 사용자 생성 (ADMIN, MANAGER, USER)
+     */
+    public static Users createWithCompany(String email, String password, String name,
+                                          Companies company, UserRole role) {
+        if (company == null && role != UserRole.SUPER) {
+            throw new IllegalArgumentException("SUPER 외 역할은 반드시 기업을 지정해야 합니다.");
+        }
+        return Users.builder()
+                .email(email)
+                .password(password)
+                .name(name)
+                .company(company)
+                .role(role)
+                .status(role == UserRole.ADMIN ? UserStatus.INACTIVE : UserStatus.ACTIVE)
+                .isFirstLogin(role == UserRole.ADMIN || role == UserRole.MANAGER)
+                .build();
     }
 }

--- a/src/main/java/org/example/unibooker/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/unibooker/domain/user/repository/UserRepository.java
@@ -20,6 +20,8 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<Users, Long> {
 
+    // ========== 기본 조회 ==========
+
     /**
      * 이메일로 사용자 조회
      */
@@ -30,7 +32,12 @@ public interface UserRepository extends JpaRepository<Users, Long> {
      */
     boolean existsByEmail(String email);
 
-    // ========== 역할별 이메일 중복 확인 (추가) ==========
+    /**
+     * 이메일로 모든 사용자 조회 (여러 기업에 가입한 경우)
+     */
+    List<Users> findAllByEmail(String email);
+
+    // ========== 역할별 이메일 중복 확인 ==========
 
     /**
      * ADMIN과 MANAGER 통합 중복 체크
@@ -41,52 +48,67 @@ public interface UserRepository extends JpaRepository<Users, Long> {
 
     /**
      * 이메일과 권한 목록으로 사용자 조회
-     * - ADMIN 회원가입 상태 조회 시 사용
      */
     List<Users> findByEmailAndRoleIn(String email, List<UserRole> roles);
 
     /**
-     * USER 중복 체크 (같은 Company + USER role)
-     * - 같은 회사 내에서만 USER 이메일 고유성 보장
+     * DELETED 상태가 아닌 사용자 중 이메일과 권한 목록으로 존재 여부 확인
      */
-    boolean existsByEmailAndCompanyIdAndRole(String email, Long companyId, UserRole role);
-
-    // ========== 기업별 이메일 중복 확인 ==========
+    boolean existsByEmailAndRoleInAndStatusNot(String email, List<UserRole> roles, UserStatus status);
 
     /**
-     * 이메일과 기업 ID로 사용자 조회
+     * 이메일과 권한 목록으로 사용자 조회 (DELETED 제외)
      */
-    Optional<Users> findByEmailAndCompanyIdAndRoleAndStatusNot(
-            String email,
-            Long companyId,
-            UserRole role,
-            UserStatus status
-    );
+    List<Users> findByEmailAndRoleInAndStatusNot(String email, List<UserRole> roles, UserStatus status);
+
+    // ========== 기업별 조회 ==========
+
+    /**
+     * USER 중복 체크 (같은 기업 + USER role)
+     */
+    boolean existsByEmailAndCompany_IdAndRole(String email, Long companyId, UserRole role);
 
     /**
      * 특정 기업 내에서 이메일 존재 여부 확인
      */
-    boolean existsByEmailAndCompanyId(String email, Long companyId);
+    boolean existsByEmailAndCompany_Id(String email, Long companyId);
 
     /**
-     * 이메일로 모든 사용자 조회 (여러 기업에 가입한 경우)
+     * 기업과 권한으로 사용자 조회
      */
-    List<Users> findAllByEmail(String email);
+    Optional<Users> findByCompany_IdAndRole(Long companyId, UserRole role);
 
     /**
-     * 기업 ID와 권한으로 사용자 조회
+     * 기업과 권한으로 사용자 목록 조회
      */
-    Optional<Users> findByCompanyIdAndRole(Long companyId, UserRole role);
+    List<Users> findAllByCompany_IdAndRole(Long companyId, UserRole role);
 
     /**
-     * 기업 ID와 권한으로 사용자 목록 조회
+     * 기업과 권한으로 사용자 페이징 조회
      */
-    List<Users> findAllByCompanyIdAndRole(Long companyId, UserRole role);
+    Page<Users> findByCompany_IdAndRole(Long companyId, UserRole role, Pageable pageable);
 
     /**
-     * 기업 ID와 권한으로 사용자 페이징 조회
+     * 기업과 여러 권한으로 사용자 목록 조회
      */
-    Page<Users> findByCompanyIdAndRole(Long companyId, UserRole role, Pageable pageable);
+    List<Users> findByCompany_IdAndRoleIn(Long companyId, List<UserRole> roles);
+
+    /**
+     * 기업과 권한으로 사용자 수 조회
+     */
+    long countByCompany_IdAndRole(Long companyId, UserRole role);
+
+    // ========== 상태별 조회 ==========
+
+    /**
+     * DELETED 상태가 아닌 사용자 중 이메일 존재 여부 확인
+     */
+    boolean existsByEmailAndStatusNot(String email, UserStatus status);
+
+    /**
+     * 이메일과 상태로 사용자 조회
+     */
+    Optional<Users> findByEmailAndStatus(String email, UserStatus status);
 
     /**
      * 권한과 상태로 사용자 페이징 조회
@@ -108,35 +130,54 @@ public interface UserRepository extends JpaRepository<Users, Long> {
      */
     Page<Users> findByRoleIn(List<UserRole> roles, Pageable pageable);
 
-    /**
-     * DELETED 상태가 아닌 사용자 중 이메일 존재 여부 확인
-     */
-    boolean existsByEmailAndStatusNot(String email, UserStatus status);
+    // ========== 기업 + 상태 조합 조회 ==========
 
     /**
-     * DELETED 상태가 아닌 사용자 중 이메일과 기업 ID, 권한으로 존재 여부 확인
+     * 이메일과 기업, 권한으로 사용자 조회 (DELETED 제외)
      */
-    boolean existsByEmailAndCompanyIdAndRoleAndStatusNot(String email, Long companyId, UserRole role, UserStatus status);
+    Optional<Users> findByEmailAndCompany_IdAndRoleAndStatusNot(
+            String email,
+            Long companyId,
+            UserRole role,
+            UserStatus status
+    );
 
     /**
-     * DELETED 상태가 아닌 사용자 중 이메일과 권한 목록으로 존재 여부 확인
+     * DELETED 상태가 아닌 사용자 중 이메일과 기업, 권한으로 존재 여부 확인
      */
-    boolean existsByEmailAndRoleInAndStatusNot(String email, List<UserRole> roles, UserStatus status);
+    boolean existsByEmailAndCompany_IdAndRoleAndStatusNot(
+            String email,
+            Long companyId,
+            UserRole role,
+            UserStatus status
+    );
 
     /**
-     * 이메일과 상태로 사용자 조회 (재가입 시 탈퇴 계정 찾기용)
+     * 이메일, 기업, 권한, 상태로 사용자 조회 (재가입 시 탈퇴 계정 찾기)
      */
-    Optional<Users> findByEmailAndStatus(String email, UserStatus status);
+    Optional<Users> findByEmailAndCompany_IdAndRoleAndStatus(
+            String email,
+            Long companyId,
+            UserRole role,
+            UserStatus status
+    );
 
     /**
-     * 이메일, 기업 ID, 권한, 상태로 사용자 조회 (재가입 시 탈퇴 계정 찾기용)
+     * 기업과 권한으로 사용자 페이징 조회 (DELETED 제외)
      */
-    Optional<Users> findByEmailAndCompanyIdAndRoleAndStatus(String email, Long companyId, UserRole role, UserStatus status);
+    Page<Users> findByCompany_IdAndRoleAndStatusNot(
+            Long companyId,
+            UserRole role,
+            UserStatus status,
+            Pageable pageable
+    );
+
+    // ========== 이메일 찾기 (이름 기반) ==========
 
     /**
-     * 이름 + 기업ID + 전화번호로 사용자 조회 (USER 역할, DELETED 제외)
+     * 이름 + 기업 + 전화번호로 사용자 조회 (DELETED 제외)
      */
-    Optional<Users> findByNameAndCompanyIdAndPhoneAndRoleAndStatusNot(
+    Optional<Users> findByNameAndCompany_IdAndPhoneAndRoleAndStatusNot(
             String name,
             Long companyId,
             String phone,
@@ -145,9 +186,9 @@ public interface UserRepository extends JpaRepository<Users, Long> {
     );
 
     /**
-     * 이름 + 기업ID + 생년월일로 사용자 조회 (USER 역할, DELETED 제외)
+     * 이름 + 기업 + 생년월일로 사용자 조회 (DELETED 제외)
      */
-    Optional<Users> findByNameAndCompanyIdAndBirthDateAndRoleAndStatusNot(
+    Optional<Users> findByNameAndCompany_IdAndBirthDateAndRoleAndStatusNot(
             String name,
             Long companyId,
             String birthDate,
@@ -155,16 +196,11 @@ public interface UserRepository extends JpaRepository<Users, Long> {
             UserStatus status
     );
 
-    /**
-     * 이메일과 권한 목록으로 사용자 조회 (DELETED 제외)
-     * - ADMIN/MANAGER/SUPER 로그인 시 사용
-     */
-    List<Users> findByEmailAndRoleInAndStatusNot(String email, List<UserRole> roles, UserStatus status);
+    // ========== 자동 삭제 대상 조회 ==========
 
     /**
-     * 미활성 첫 로그인 계정 조회 (자동 삭제 대상)
+     * 미활성 첫 로그인 계정 조회
      * - ADMIN/MANAGER 중 isFirstLogin=true
-     * - status=ACTIVE (INACTIVE, SUSPENDED, DELETED 제외)
      * - 생성일이 특정 시간 이전
      */
     List<Users> findByRoleInAndStatusAndIsFirstLoginAndCreatedAtBefore(
@@ -174,31 +210,17 @@ public interface UserRepository extends JpaRepository<Users, Long> {
             LocalDateTime createdAtBefore
     );
 
-    /**
-     * 기업 ID와 권한으로 사용자 페이징 조회 (DELETED 제외)
-     */
-    Page<Users> findByCompanyIdAndRoleAndStatusNot(
-            Long companyId,
-            UserRole role,
-            UserStatus status,
-            Pageable pageable
-    );
+    // ========== 통계 조회 ==========
 
-    // 월별 누적 가입자 수 조회
+    /**
+     * 월별 누적 가입자 수 조회
+     */
     int countAllByRoleAndCreatedAtBefore(UserRole role, LocalDateTime before);
-    // 활성 상태인 특정 Role의 계정 수 조회
+
+    /**
+     * 활성 상태인 특정 Role의 계정 수 조회
+     */
     int countAllByRoleAndStatus(UserRole userRole, UserStatus status);
-
-    /**
-     * 기업 ID와 여러 권한으로 사용자 목록 조회
-     * - 기업 정지 시 소속 ADMIN/MANAGER 일괄 정지용
-     */
-    List<Users> findByCompanyIdAndRoleIn(Long companyId, List<UserRole> roles);
-
-    /**
-     * 기업 ID와 권한으로 사용자 수 조회
-     */
-    long countByCompanyIdAndRole(Long companyId, UserRole role);
 
     /**
      * 특정 기업의 일반 사용자(USER) 수 조회
@@ -212,7 +234,11 @@ public interface UserRepository extends JpaRepository<Users, Long> {
     @Query("SELECT MAX(u.updatedAt) FROM Users u WHERE u.company.id = :companyId AND u.role = 'USER'")
     LocalDateTime findLastLoginByCompanyId(@Param("companyId") Long companyId);
 
+    // ========== Fetch Join 조회 ==========
+
+    /**
+     * 사용자 조회 (Company Fetch Join)
+     */
     @Query("SELECT u FROM Users u LEFT JOIN FETCH u.company WHERE u.id = :userId")
     Optional<Users> findByIdWithCompany(@Param("userId") Long userId);
-
 }

--- a/src/main/java/org/example/unibooker/domain/user/service/AdminService.java
+++ b/src/main/java/org/example/unibooker/domain/user/service/AdminService.java
@@ -392,7 +392,7 @@ public class AdminService {
                     .orElseThrow(() -> new BaseException(BaseResponseStatus.COMPANY_NOT_FOUND));
 
             // 2. 관리자 조회
-            Users admin = userRepository.findByCompanyIdAndRole(companyId, UserRole.ADMIN)
+            Users admin = userRepository.findByCompany_IdAndRole(companyId, UserRole.ADMIN)
                     .orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
 
             // 3. 플랫폼 이용 현황 데이터 조회
@@ -447,7 +447,7 @@ public class AdminService {
             }
 
             // 3. Admin User 조회
-            Users admin = userRepository.findByCompanyIdAndRole(companyId, UserRole.ADMIN)
+            Users admin = userRepository.findByCompany_IdAndRole(companyId, UserRole.ADMIN)
                     .orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
 
             // 4. 새로운 임시 비밀번호 생성
@@ -619,7 +619,7 @@ public class AdminService {
          * Company -> PendingResponse DTO 변환
          */
         private CompanyDto.PendingResponse convertToPendingResponse(Companies company) {
-            Users admin = userRepository.findByCompanyIdAndRole(company.getId(), UserRole.ADMIN)
+            Users admin = userRepository.findByCompany_IdAndRole(company.getId(), UserRole.ADMIN)
                     .orElse(null);
 
             return CompanyDto.PendingResponse.builder()
@@ -683,7 +683,7 @@ public class AdminService {
             validateEmailDuplicate(request.getEmail(), admin.getCompany().getId());
 
             // 4. 같은 기업의 DELETED MANAGER 계정 찾기
-            Optional<Users> deletedManager = userRepository.findByEmailAndCompanyIdAndRoleAndStatus(
+            Optional<Users> deletedManager = userRepository.findByEmailAndCompany_IdAndRoleAndStatus(
                     request.getEmail(),
                     admin.getCompany().getId(),
                     UserRole.MANAGER,
@@ -727,7 +727,7 @@ public class AdminService {
             Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 
             // 3. 같은 기업의 매니저 조회 (DELETED 제외)
-            Page<Users> managerPage = userRepository.findByCompanyIdAndRoleAndStatusNot(
+            Page<Users> managerPage = userRepository.findByCompany_IdAndRoleAndStatusNot(
                     admin.getCompany().getId(),
                     UserRole.MANAGER,
                     UserStatus.DELETED,

--- a/src/main/java/org/example/unibooker/domain/user/service/AuthService.java
+++ b/src/main/java/org/example/unibooker/domain/user/service/AuthService.java
@@ -45,7 +45,7 @@ public class AuthService {
      */
     public UserDto.LoginResponseWithToken loginWithCompany(String email, String password, Long companyId) {
         // 1. 사용자 조회 (USER role 명시, DELETED 제외)
-        Users user = userRepository.findByEmailAndCompanyIdAndRoleAndStatusNot(
+        Users user = userRepository.findByEmailAndCompany_IdAndRoleAndStatusNot(
                         email,
                         companyId,
                         UserRole.USER,  // ← role 명시 추가

--- a/src/main/java/org/example/unibooker/domain/user/service/SuperService.java
+++ b/src/main/java/org/example/unibooker/domain/user/service/SuperService.java
@@ -53,7 +53,7 @@ public class SuperService {
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.COMPANY_NOT_FOUND));
 
         // 해당 기업의 ADMIN, MANAGER 조회
-        List<Users> managers = userRepository.findByCompanyIdAndRoleIn(
+        List<Users> managers = userRepository.findByCompany_IdAndRoleIn(
                 companyId,
                 List.of(UserRole.ADMIN, UserRole.MANAGER)
         );

--- a/src/main/java/org/example/unibooker/domain/user/service/UserService.java
+++ b/src/main/java/org/example/unibooker/domain/user/service/UserService.java
@@ -56,7 +56,7 @@ public class UserService {
         }
 
         // 3. 탈퇴한 계정이 있는지 확인
-        Optional<Users> deletedUser = userRepository.findByEmailAndCompanyIdAndRoleAndStatus(
+        Optional<Users> deletedUser = userRepository.findByEmailAndCompany_IdAndRoleAndStatus(
                 request.getEmail(),
                 request.getCompanyId(),
                 UserRole.USER,
@@ -77,18 +77,17 @@ public class UserService {
             // 3-2. DELETED 아닌 상태에서 중복 확인
             validateDuplicateEmailInCompany(request.getEmail(), request.getCompanyId());
 
-            // 3-3. 신규 사용자 생성
-            user = Users.builder()
-                    .email(request.getEmail())
-                    .password(passwordEncoder.encode(request.getPassword()))
-                    .name(request.getName())
-                    .phone(request.getPhone())
-                    .birthDate(request.getBirthDate())
-                    .gender(request.getGender())
-                    .company(company)
-                    .role(UserRole.USER)
-                    .status(UserStatus.ACTIVE)
-                    .build();
+// 3-3. 신규 사용자 생성 (정적 팩토리 메서드 사용)
+            user = Users.createWithCompany(
+                    request.getEmail(),
+                    passwordEncoder.encode(request.getPassword()),
+                    request.getName(),
+                    company,
+                    UserRole.USER
+            );
+            user.updatePhone(request.getPhone());
+            user.updateBirthDate(request.getBirthDate());
+            user.updateGender(request.getGender());
         }
 
         Users savedUser = userRepository.save(user);
@@ -108,8 +107,13 @@ public class UserService {
      * 특정 기업 내에서 USER 이메일 중복 확인 (DELETED 제외)
      */
     private void validateDuplicateEmailInCompany(String email, Long companyId) {
-        if (userRepository.existsByEmailAndCompanyIdAndRoleAndStatusNot(
-                email, companyId, UserRole.USER, UserStatus.DELETED)) {
+        boolean exists = userRepository.existsByEmailAndCompany_IdAndRoleAndStatusNot(
+                email,
+                companyId,
+                UserRole.USER,
+                UserStatus.DELETED
+        );
+        if (exists) {
             throw new BaseException(BaseResponseStatus.DUPLICATE_EMAIL_IN_COMPANY);
         }
     }
@@ -118,8 +122,7 @@ public class UserService {
      * 특정 기업 내에서 이메일 중복 여부 확인
      */
     public boolean existsByEmailAndCompany(String email, Long companyId) {
-        // USER Role만 체크하도록 수정
-        return userRepository.existsByEmailAndCompanyIdAndRoleAndStatusNot(
+        return userRepository.existsByEmailAndCompany_IdAndRoleAndStatusNot(
                 email,
                 companyId,
                 UserRole.USER,
@@ -152,19 +155,18 @@ public class UserService {
                 .map(user -> {
                     // 기업 정보 조회
                     String companyName = null;
-                    if (user.getCompany().getId() != null) {
-                        Companies company = companyRepository.findById(user.getCompany().getId())
-                                .orElse(null);
-                        if (company != null) {
-                            companyName = company.getCompanyName();
-                        }
+                    Long companyId = null;
+
+                    if (user.getCompany() != null) {
+                        companyId = user.getCompany().getId();
+                        companyName = user.getCompany().getCompanyName();
                     }
 
                     return UserDto.AccountInfo.builder()
                             .userId(user.getId())
                             .email(user.getEmail())
                             .name(user.getName())
-                            .companyId(user.getCompany().getId())
+                            .companyId(companyId)
                             .companyName(companyName)
                             .role(user.getRole())
                             .status(user.getStatus())
@@ -197,19 +199,21 @@ public class UserService {
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
 
         // 2. 기업 정보 조회
-        Companies company = null;
-        if (user.getCompany().getId() != null) {
-            company = companyRepository.findById(user.getCompany().getId())
-                    .orElseThrow(() -> new BaseException(BaseResponseStatus.COMPANY_NOT_FOUND));
+        Long companyId = null;
+        String companySlug = null;
+
+        if (user.getCompany() != null) {
+            companyId = user.getCompany().getId();
+            companySlug = user.getCompany().getCompanySlug();
         }
 
-        // 3. Response 생성
+// 3. Response 생성
         return UserDto.CurrentUserResponse.builder()
                 .id(user.getId())
                 .email(user.getEmail())
                 .name(user.getName())
-                .companyId(company != null ? company.getId() : null)
-                .companySlug(company != null ? company.getCompanySlug() : null)  // ← getSlug() → getCompanySlug()
+                .companyId(companyId)
+                .companySlug(companySlug)
                 .role(user.getRole())
                 .status(user.getStatus())
                 .build();
@@ -290,22 +294,20 @@ public class UserService {
         Users user = userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
 
-        // 2. 기업명 및 로고 조회
+        // 2. 기업 정보 조회
+        Long companyId = null;
         String companyName = null;
         String businessNumber = null;
-        String logoUrl = null;  // ← 추가
+        String logoUrl = null;
 
-        if (user.getCompany().getId() != null) {
-            Companies company = companyRepository.findById(user.getCompany().getId())
-                    .orElse(null);
-            if (company != null) {
-                companyName = company.getCompanyName();
-                businessNumber = company.getBusinessNumber();
-                logoUrl = company.getLogoUrl();  // ← 추가
-            }
+        if (user.getCompany() != null) {
+            companyId = user.getCompany().getId();
+            companyName = user.getCompany().getCompanyName();
+            businessNumber = user.getCompany().getBusinessNumber();
+            logoUrl = user.getCompany().getLogoUrl();
         }
 
-        // 3. Response 생성
+// 3. Response 생성
         return UserDto.ProfileResponse.builder()
                 .id(user.getId())
                 .name(user.getName())
@@ -315,10 +317,10 @@ public class UserService {
                 .gender(user.getGender())
                 .role(user.getRole())
                 .status(user.getStatus())
-                .companyId(user.getCompany().getId())
+                .companyId(companyId)
                 .companyName(companyName)
                 .businessNumber(businessNumber)
-                .logoUrl(logoUrl)  // ← 추가
+                .logoUrl(logoUrl)
                 .isFirstLogin(user.getIsFirstLogin())
                 .createdAt(user.getCreatedAt())
                 .updatedAt(user.getUpdatedAt())
@@ -362,44 +364,12 @@ public class UserService {
     }
 
     /**
-     * 이메일 중복 체크
-     */
-    private void validateDuplicateEmail(String email) {
-        if (userRepository.findByEmail(email).isPresent()) {
-            throw new BaseException(BaseResponseStatus.DUPLICATE_EMAIL);
-        }
-    }
-
-    /**
-     * 사용자 상태 검증
-     */
-    private void validateUserStatus(Users user) {
-        // INACTIVE - 관리자는 승인 대기, 일반 사용자는 이메일 인증 대기
-        if (user.isInactive()) {
-            if (user.isManager() || user.isAdmin()) {
-                throw new BaseException(BaseResponseStatus.APPROVAL_PENDING);
-            }
-            // 일반 사용자의 INACTIVE는 현재 자동 ACTIVE 처리되므로 발생하지 않음
-        }
-
-        // SUSPENDED - 정지된 계정
-        if (user.isSuspended()) {
-            throw new BaseException(BaseResponseStatus.ACCOUNT_SUSPENDED);
-        }
-
-        // DELETED - 탈퇴한 계정
-        if (user.isDeleted()) {
-            throw new BaseException(BaseResponseStatus.ACCOUNT_DELETED);
-        }
-    }
-
-    /**
      * 비밀번호 찾기 - 임시 비밀번호 발급
      */
     @Transactional
     public void resetPassword(String email, Long companyId) {
         // 1. 사용자 조회 (USER 역할만)
-        Users user = userRepository.findByEmailAndCompanyIdAndRoleAndStatusNot(
+        Users user = userRepository.findByEmailAndCompany_IdAndRoleAndStatusNot(
                 email,
                 companyId,
                 UserRole.USER,
@@ -445,7 +415,7 @@ public class UserService {
 
         // 1. 전화번호로 찾기 (우선순위 1)
         if (request.getPhone() != null && !request.getPhone().isBlank()) {
-            user = userRepository.findByNameAndCompanyIdAndPhoneAndRoleAndStatusNot(
+            user = userRepository.findByNameAndCompany_IdAndPhoneAndRoleAndStatusNot(
                     request.getName(),
                     request.getCompanyId(),
                     request.getPhone(),
@@ -454,9 +424,9 @@ public class UserService {
             ).orElse(null);
         }
 
-        // 2. 생년월일로 찾기 (우선순위 2)
+// 2. 생년월일로 찾기
         if (user == null && request.getBirthDate() != null && !request.getBirthDate().isBlank()) {
-            user = userRepository.findByNameAndCompanyIdAndBirthDateAndRoleAndStatusNot(
+            user = userRepository.findByNameAndCompany_IdAndBirthDateAndRoleAndStatusNot(
                     request.getName(),
                     request.getCompanyId(),
                     request.getBirthDate(),


### PR DESCRIPTION
## #️⃣ Issue Number

- #162 

## 📝 요약(Summary)

[기업 관리]
- 기업 목록 조회 및 상태 관리 (ACTIVE ↔ SUSPENDED)
- 기업 정지 시 소속 관리자/매니저 자동 정지
- 기업 상세 조회 및 관리자 계정 목록 조회

[관리자 계정 관리]
- 특정 기업의 관리자/매니저 목록 조회
- 관리자 상태 변경 기능 (ACTIVE/INACTIVE/SUSPENDED)
- 권한별 필터링 및 상태 관리

[서비스 그룹 관리]
- 특정 기업의 서비스 그룹 목록 조회
- 예외 처리 및 검증 로직 개선

## 📸스크린샷 (선택)

## 💬 공유사항

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->